### PR TITLE
Allow compilation for targets without EGD (ie LibreSSL)

### DIFF
--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -522,7 +522,9 @@ rb_init_prng(const char *path, prng_seed_t seed_type)
 {
 /* We may not have EGD (old OpenSSL / LibreSSL), fall back to default */
 #ifndef HAVE_SSL_RAND_EGD
-    seed_type = RB_PRNG_DEFAULT;
+    if (seed_type == RB_PRNG_EGD) {
+        seed_type = RB_PRNG_DEFAULT;
+    }
 #endif
 
     if(seed_type == RB_PRNG_DEFAULT) {


### PR DESCRIPTION
Quick fix [(wget-style)](https://github.com/gentoo/libressl/blob/master/net-misc/wget/files/wget-1.14-libressl.patch) to enable compilation with LibreSSL.

Compiles and works under FreeBSD 10.0 / LibreSSL 2.0.3

PS: I don't know if I went against any coding practice because I couldn't find a
 CONTRIBUTING file nor there is anything on the README.. so if I did.. sorry :(
