### PR TITLE
add usermode for webchat users (fix)

### DIFF
--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -129,7 +129,9 @@ mr_webirc(struct Client *client_p, struct Client *source_p, int parc, const char
             return 0;
         }
     }
-
+         /* Set UMODE_WEBCLIENT */
+         source_p->umodes = source_p->umodes | UMODE_WEBCLIENT;
+         
     sendto_one(source_p, "NOTICE * :CGI:IRC host/IP set to %s %s", parv[3], parv[4]);
     return 0;
 }

--- a/help/opers/umode
+++ b/help/opers/umode
@@ -28,3 +28,4 @@ User modes: (* designates that the umode is oper only)
          +I     - Prevents non-opers from seeing your channel list in
                   a whois query.
          +Z     - Is connected via SSL (set only on connection).
+         +W     - Is connected via a web client (set only on connection).

--- a/help/users/umode
+++ b/help/users/umode
@@ -22,3 +22,4 @@ User modes: (? designates that the umode is provided by an extension
                   anyone who's in a common channel with you to message you.
          +V     - Prevents you from receiving invites.
          +Z     - Is connected via SSL (set only on connection).
+         +W     - Is connected via a web client (set only on connection).

--- a/include/client.h
+++ b/include/client.h
@@ -425,6 +425,7 @@ struct ListClient {
 #define UMODE_OPER         0x1000	/* Operator */
 #define UMODE_ADMIN        0x2000	/* Admin on server */
 #define UMODE_SSLCLIENT    0x4000	/* using SSL */
+#define UMODE_WEBCLIENT    0x100000 /* user is connected via a web client */
 #define UMODE_OVERRIDE     0x20000  /* able to override */
 
 #define IsOverride(x)      ((x)->umodes & UMODE_OVERRIDE)

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -330,7 +330,7 @@ extern const char *form_str(int);
 #define ERR_HELPNOTFOUND     524
 
 #define RPL_WHOISSECURE      671 /* Unreal3.2 --nenolod */
-
+#define RPL_WHOISWEBIRC      672 /* plexus -- XE */
 #define RPL_MODLIST          702
 #define RPL_ENDOFMODLIST     703
 

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -313,6 +313,13 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
     if(IsSSLClient(target_p))
         sendto_one_numeric(source_p, RPL_WHOISSECURE, form_str(RPL_WHOISSECURE),
                            target_p->name);
+                           
+                           
+    if(!(target_p->umodes & UMODE_HIDECHANS)) {
+        sendto_one_numeric(source_p, RPL_WHOISWEBIRC, form_str(RPL_WHOISWEBIRC),
+                                  target_p->name);
+    }
+    
     if((source_p == target_p || IsOper(source_p)) &&
        target_p->certfp != NULL)
         sendto_one_numeric(source_p, RPL_WHOISCERTFP,

--- a/src/messages.tab
+++ b/src/messages.tab
@@ -693,7 +693,7 @@ static  const char *  replies[] = {
 /* 669 */	NULL,
 /* 670 */	NULL,
 /* 671 RPL_WHOISSECURE, */	"%s :is using a secure connection",
-/* 672 */	NULL,
+/* 672 RPL_WHOISWEBIRC, */	"%s :is using a web IRC client",
 /* 673 */	NULL,
 /* 674 */	NULL,
 /* 675 */	NULL,

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -88,7 +88,7 @@ int user_modes[256] = {
     0,			/* T */
     0,			/* U */
     UMODE_NOINVITE,		/* V */
-    0,			/* W */
+    UMODE_WEBCLIENT,	/* W */
     0,			/* X */
     0,			/* Y */
     UMODE_SSLCLIENT,	/* Z */

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1018,6 +1018,7 @@ user_mode(struct Client *client_p, struct Client *source_p, int parc, const char
             /* can only be set on burst */
         case 'S':
         case 'Z':
+        case 'W':
         case ' ':
         case '\n':
         case '\r':


### PR DESCRIPTION
modules/m_whois.c: there was an important line missing so when you done a /whois on a user it come back a load of garbage. So added target_p->name and it responds nick is using a web IRC client