### PR TITLE
Ssld cleanup

### DIFF
--- a/bandb/Makefile.in
+++ b/bandb/Makefile.in
@@ -29,9 +29,7 @@ PACKAGE_TARNAME = @PACKAGE_TARNAME@
 
 PROGRAM_PREFIX   = @PROGRAM_PREFIX@
 
-ZIP_LIB		= @ZLIB_LD@
-
-IRCDLIBS	= @MODULES_LIBS@ -L../libratbox/src/.libs -lratbox @LIBS@ $(SSL_LIBS) $(ZIP_LIB)
+IRCDLIBS	= @MODULES_LIBS@ -L../libratbox/src/.libs -lratbox @LIBS@ $(SSL_LIBS)
 
 INCLUDES        = -I. -I../include -I../libratbox/include $(SSL_INCLUDES)
 CPPFLAGS        = ${INCLUDES} @CPPFLAGS@

--- a/configure
+++ b/configure
@@ -642,7 +642,6 @@ HELP_DIR
 logdir
 LOG_DIR
 ETC_DIR
-ZLIB_LD
 ENCSPEED
 ALLOCA
 VICONF
@@ -730,8 +729,6 @@ enable_option_checking
 enable_fhs_paths
 enable_ipv6
 enable_openssl
-with_zlib_path
-enable_zlib
 enable_ports
 enable_poll
 enable_select
@@ -1376,7 +1373,6 @@ Optional Features:
   --enable-ipv6           Enable IPv6 support
   --enable-openssl=DIR    Enable OpenSSL support (DIR optional).
   --disable-openssl       Disable OpenSSL support.
-  --disable-zlib          Disable ziplinks support
   --enable-ports          Force solaris I/O ports subsystem usage.
   --enable-poll           Force poll() usage.
   --enable-select         Force select() usage.
@@ -1393,7 +1389,6 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-zlib-path=DIR    Path to libz.so for ziplinks support.
   --with-confdir=DIR      Directory to install config files [deprecated, use
                           --sysconfdir instead].
   --with-logdir=DIR       Directory where to write logfiles.
@@ -7160,84 +7155,6 @@ LIBS="$save_LIBS"
 
 
 
-
-# Check whether --with-zlib-path was given.
-if test "${with_zlib_path+set}" = set; then :
-  withval=$with_zlib_path; LIBS="$LIBS -L$withval"
-fi
-
-
-# Check whether --enable-zlib was given.
-if test "${enable_zlib+set}" = set; then :
-  enableval=$enable_zlib; zlib=$enableval
-else
-  zlib=yes
-fi
-
-
-if test "$zlib" = yes; then
-
-ac_fn_c_check_header_mongrel "$LINENO" "zlib.h" "ac_cv_header_zlib_h" "$ac_includes_default"
-if test "x$ac_cv_header_zlib_h" = xyes; then :
-
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for zlibVersion in -lz" >&5
-$as_echo_n "checking for zlibVersion in -lz... " >&6; }
-if ${ac_cv_lib_z_zlibVersion+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lz  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char zlibVersion ();
-int
-main ()
-{
-return zlibVersion ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_z_zlibVersion=yes
-else
-  ac_cv_lib_z_zlibVersion=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_z_zlibVersion" >&5
-$as_echo "$ac_cv_lib_z_zlibVersion" >&6; }
-if test "x$ac_cv_lib_z_zlibVersion" = xyes; then :
-
-		ZLIB_LD=-lz
-
-
-$as_echo "#define HAVE_LIBZ 1" >>confdefs.h
-
-
-else
-  zlib=no
-fi
-
-
-else
-  zlib=no
-fi
-
-
-
-fi
-
-
 # Check whether --enable-ports was given.
 if test "${enable_ports+set}" = set; then :
   enableval=$enable_ports;  if test $enableval = yes; then
@@ -11056,7 +10973,6 @@ echo "
 Configuration:
 	Install directory  : $prefix
 
-	Ziplinks           : $zlib
 	OpenSSL            : $openssl
 	Socket Engine      : $SELECT_TYPE
 	Small network      : $small_net

--- a/configure.ac
+++ b/configure.ac
@@ -541,29 +541,6 @@ LIBS="$save_LIBS"
 dnl End OpenSSL detection
 
 
-dnl Specialized functions and libraries
-dnl ===================================
-
-AC_ARG_WITH(zlib-path,
-AC_HELP_STRING([--with-zlib-path=DIR],[Path to libz.so for ziplinks support.]),
-[LIBS="$LIBS -L$withval"],)
-
-AC_ARG_ENABLE(zlib,
-AC_HELP_STRING([--disable-zlib],[Disable ziplinks support]),
-[zlib=$enableval],[zlib=yes])
-
-if test "$zlib" = yes; then
-
-AC_CHECK_HEADER(zlib.h, [
-	AC_CHECK_LIB(z, zlibVersion,
-	[
-		AC_SUBST(ZLIB_LD, -lz)
-		AC_DEFINE(HAVE_LIBZ, 1, [Define to 1 if zlib (-lz) is available.])
-	], zlib=no)
-], zlib=no)
-
-fi
-
 dnl IO Loop Selection
 dnl =================
 
@@ -1230,7 +1207,6 @@ echo "
 Configuration:
 	Install directory  : $prefix
 
-	Ziplinks           : $zlib
 	OpenSSL            : $openssl
 	Socket Engine      : $SELECT_TYPE
 	Small network      : $small_net

--- a/doc/reference.charybdis.conf
+++ b/doc/reference.charybdis.conf
@@ -598,7 +598,6 @@ connect "irc.uplink.com" {
 	/* flags: controls special options for this server
 	 * encrypted	- marks the accept_password as being crypt()'d
 	 * autoconn	- automatically connect to this server
-	 * compressed	- compress traffic via ziplinks
 	 * topicburst	- burst topics between servers
 	 * ssl		- ssl/tls encrypted server connections
 	 */

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -601,7 +601,6 @@ connect "irc.uplink.com" {
 	/* flags: controls special options for this server
 	 * encrypted	- marks the accept_password as being crypt()'d
 	 * autoconn	- automatically connect to this server
-	 * compressed	- compress traffic via ziplinks
 	 * topicburst	- burst topics between servers
 	 * ssl		- ssl/tls encrypted server connections
 	 */

--- a/doc/sgml/oper-guide/commands.sgml
+++ b/doc/sgml/oper-guide/commands.sgml
@@ -1095,12 +1095,6 @@
 	    </listitem>
 	  </varlistentry>
 	  <varlistentry>
-	    <term>Z</term>
-	    <listitem>
-	      <para>Show ziplinks statistics</para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry>
 	    <term>?</term>
 	    <listitem>
 	      <para>Show connected servers and link information about them</para>

--- a/doc/sgml/oper-guide/config.sgml
+++ b/doc/sgml/oper-guide/config.sgml
@@ -695,16 +695,6 @@ connect "<replaceable>name</replaceable>" {
 	    </listitem>
 	  </varlistentry>
 	  <varlistentry>
-	    <term>compressed</term>
-	    <listitem>
-	      <para>Ziplinks should be used with this server connection.
-	      This compresses traffic using zlib, saving some bandwidth
-	      and speeding up netbursts.</para>
-	      <para>If you have trouble setting up a link, you should
-	      turn this off as it often hides error messages.</para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry>
 	    <term>topicburst</term>
 	    <listitem>
 	      <para>Topics should be bursted to this server.</para>

--- a/help/opers/stats
+++ b/help/opers/stats
@@ -40,5 +40,4 @@ X f - Shows File Descriptors
 * X - Shows gecos bans (Old X: lines)
 ^ y - Shows connection classes (Old Y: lines)
 * z - Shows memory stats
-* Z - Shows ziplinks stats
 ^ ? - Shows connected servers and sendq info about them

--- a/include/client.h
+++ b/include/client.h
@@ -97,15 +97,6 @@ struct Server {
     struct scache_entry *nameinfo;
 };
 
-struct ZipStats {
-    unsigned long long in;
-    unsigned long long in_wire;
-    unsigned long long out;
-    unsigned long long out_wire;
-    double in_ratio;
-    double out_ratio;
-};
-
 struct Client {
     rb_dlink_node node;
     rb_dlink_node lnode;
@@ -270,9 +261,7 @@ struct LocalUser {
 			      applicable to this client */
 
     struct _ssl_ctl *ssl_ctl;		/* which ssl daemon we're associate with */
-    struct _ssl_ctl *z_ctl;			/* second ctl for ssl+zlib */
     uint32_t localflags;
-    struct ZipStats *zipstats;		/* zipstats */
     uint16_t cork_count;			/* used for corking/uncorking connections */
     struct ev_entry *event;			/* used for associated events */
 

--- a/include/ircd.h
+++ b/include/ircd.h
@@ -107,7 +107,6 @@ extern int testing_conf;
 extern struct ev_entry *check_splitmode_ev;
 
 extern int ssl_ok;
-extern int zlib_ok;
 extern int maxconnections;
 
 void ircd_shutdown(const char *reason);

--- a/include/listener.h
+++ b/include/listener.h
@@ -31,16 +31,16 @@
 struct Client;
 
 struct Listener {
-    struct Listener *next;	/* list node pointer */
-    const char *name;	/* listener name */
-    rb_fde_t *F;		/* file descriptor */
-    int ref_count;		/* number of connection references */
-    int active;		/* current state of listener */
-    int ssl;		/* ssl listener */
-    int defer_accept;       /* use TCP_DEFER_ACCEPT */
+    struct Listener *next;   /* list node pointer */
+    const char *name;        /* listener name */
+    rb_fde_t *F;             /* file descriptor */
+    int ref_count;           /* number of connection references */
+    int active;              /* current state of listener */
+    int ssl;                 /* ssl listener */
+    int defer_accept;        /* use TCP_DEFER_ACCEPT */
     struct rb_sockaddr_storage addr;
     struct DNSQuery *dns_query;
-    char vhost[HOSTLEN + 1];	/* virtual name of listener */
+    char vhost[HOSTLEN + 1]; /* virtual name of listener */
 };
 
 extern void add_listener(int port, const char *vaddr_ip, int family, int ssl, int defer_accept);

--- a/include/listener.h
+++ b/include/listener.h
@@ -30,20 +30,23 @@
 
 struct Client;
 
+#define PLAIN_PORT (0)
+#define SSL_PORT (1 << 0)
+
 struct Listener {
     struct Listener *next;   /* list node pointer */
     const char *name;        /* listener name */
     rb_fde_t *F;             /* file descriptor */
     int ref_count;           /* number of connection references */
     int active;              /* current state of listener */
-    int ssl;                 /* ssl listener */
+    int type;                /* type of listener */
     int defer_accept;        /* use TCP_DEFER_ACCEPT */
     struct rb_sockaddr_storage addr;
     struct DNSQuery *dns_query;
     char vhost[HOSTLEN + 1]; /* virtual name of listener */
 };
 
-extern void add_listener(int port, const char *vaddr_ip, int family, int ssl, int defer_accept);
+extern void add_listener(int port, const char *vaddr_ip, int family, int type, int defer_accept);
 extern void close_listener(struct Listener *listener);
 extern void close_listeners(void);
 extern const char *get_listener_name(const struct Listener *listener);

--- a/include/m_info.h
+++ b/include/m_info.h
@@ -136,12 +136,6 @@ Info MyInformation[] = {
     {"HAVE_LIBCRYPTO", "OFF", 0, "Enable OpenSSL CHALLENGE Support"},
 #endif /* HAVE_LIBCRYPTO */
 
-#ifdef HAVE_LIBZ
-    {"HAVE_LIBZ", "YES", 0, "zlib (ziplinks) support"},
-#else
-    {"HAVE_LIBZ", "NO", 0, "zlib (ziplinks)  support"},
-#endif /* HAVE_LIBZ */
-
 #ifdef PPATH
     {"PPATH", PPATH, 0, "Path to Pid File"},
 #else

--- a/include/s_serv.h
+++ b/include/s_serv.h
@@ -80,11 +80,7 @@ struct Capability {
 			 CAP_RSFNC | CAP_SAVE | CAP_EUID | CAP_EOPMOD | \
 			 CAP_BAN | CAP_MLOCK)
 
-#ifdef HAVE_LIBZ
-#define CAP_ZIP_SUPPORTED       CAP_ZIP
-#else
 #define CAP_ZIP_SUPPORTED       0
-#endif
 
 /*
  * Capability macros.

--- a/include/setup.h.in
+++ b/include/setup.h.in
@@ -78,9 +78,6 @@
 /* Define to 1 if you have the `crypto' library (-lcrypto). */
 #undef HAVE_LIBCRYPTO
 
-/* Define to 1 if zlib (-lz) is available. */
-#undef HAVE_LIBZ
-
 /* Define to 1 if you have the <machine/endian.h> header file. */
 #undef HAVE_MACHINE_ENDIAN_H
 

--- a/include/sslproc.h
+++ b/include/sslproc.h
@@ -30,7 +30,6 @@ void init_ssld(void);
 int start_ssldaemon(int count, const char *ssl_cert, const char *ssl_private_key, const char *ssl_dh_params);
 ssl_ctl_t *start_ssld_accept(rb_fde_t *sslF, rb_fde_t *plainF, int id);
 ssl_ctl_t *start_ssld_connect(rb_fde_t *sslF, rb_fde_t *plainF, int id);
-void start_zlib_session(void *data);
 void send_new_ssl_certs(const char *ssl_cert, const char *ssl_private_key, const char *ssl_dh_params);
 void ssld_decrement_clicount(ssl_ctl_t *ctl);
 int get_ssld_count(void);

--- a/include/sslproc.h
+++ b/include/sslproc.h
@@ -28,8 +28,8 @@ typedef struct _ssl_ctl ssl_ctl_t;
 
 void init_ssld(void);
 int start_ssldaemon(int count, const char *ssl_cert, const char *ssl_private_key, const char *ssl_dh_params);
-ssl_ctl_t *start_ssld_accept(rb_fde_t *sslF, rb_fde_t *plainF, int id);
-ssl_ctl_t *start_ssld_connect(rb_fde_t *sslF, rb_fde_t *plainF, int id);
+ssl_ctl_t *start_ssld_accept(rb_fde_t *sslF, rb_fde_t *plainF, int id, int32_t type);
+ssl_ctl_t *start_ssld_connect(rb_fde_t *sslF, rb_fde_t *plainF, int id, int32_t type);
 void send_new_ssl_certs(const char *ssl_cert, const char *ssl_private_key, const char *ssl_dh_params);
 void ssld_decrement_clicount(ssl_ctl_t *ctl);
 int get_ssld_count(void);

--- a/libratbox/src/balloc.c
+++ b/libratbox/src/balloc.c
@@ -234,6 +234,7 @@ newblock(rb_bh *bh)
 
     b->elems = get_block(b->alloc_size);
     if(rb_unlikely(b->elems == NULL)) {
+        rb_free(b);
         return (1);
     }
     offset = (uintptr_t)b->elems;

--- a/libratbox/src/commio.c
+++ b/libratbox/src/commio.c
@@ -57,7 +57,7 @@ static struct ev_entry *rb_timeout_ev;
 static const char *rb_err_str[] = { "Comm OK", "Error during bind()",
                                     "Error during DNS lookup", "connect timeout",
                                     "Error during connect()",
-                                    "Comm Error"
+                                    "Comm Error", "SSL Error"
                                   };
 
 /* Highest FD and number of open FDs .. */

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -116,7 +116,6 @@ static void stats_class(struct Client *);
 static void stats_memory(struct Client *);
 static void stats_servlinks(struct Client *);
 static void stats_ltrace(struct Client *, int, const char **);
-static void stats_ziplinks(struct Client *);
 static void stats_comm(struct Client *);
 /* This table contains the possible stats items, in order:
  * stats letter,  function to call, operonly? adminonly?
@@ -167,7 +166,6 @@ static struct StatsStruct stats_cmd_table[] = {
     {'y', stats_class,		0, 0, },
     {'Y', stats_class,		0, 0, },
     {'z', stats_memory,		1, 0, },
-    {'Z', stats_ziplinks,		1, 0, },
     {'?', stats_servlinks,		0, 0, },
     {(char) 0, (void (*)()) 0, 	0, 0, }
 };
@@ -1303,36 +1301,6 @@ stats_memory (struct Client *source_p)
                        "z :Remote client Memory in use: %ld(%ld)",
                        (long)remote_client_count,
                        (long)remote_client_memory_used);
-}
-
-static void
-stats_ziplinks (struct Client *source_p)
-{
-    rb_dlink_node *ptr;
-    struct Client *target_p;
-    struct ZipStats *zipstats;
-    int sent_data = 0;
-    char buf[128], buf1[128];
-    RB_DLINK_FOREACH (ptr, serv_list.head) {
-        target_p = ptr->data;
-        if(IsCapable (target_p, CAP_ZIP)) {
-            zipstats = target_p->localClient->zipstats;
-            sprintf(buf, "%.2f%%", zipstats->out_ratio);
-            sprintf(buf1, "%.2f%%", zipstats->in_ratio);
-            sendto_one_numeric(source_p, RPL_STATSDEBUG,
-                               "Z :ZipLinks stats for %s send[%s compression "
-                               "(%llu kB data/%llu kB wire)] recv[%s compression "
-                               "(%llu kB data/%llu kB wire)]",
-                               target_p->name,
-                               buf, zipstats->out >> 10,
-                               zipstats->out_wire >> 10, buf1,
-                               zipstats->in >> 10, zipstats->in_wire >> 10);
-            sent_data++;
-        }
-    }
-
-    sendto_one_numeric(source_p, RPL_STATSDEBUG,
-                       "Z :%u ziplink(s)", sent_data);
 }
 
 static void

--- a/modules/m_version.c
+++ b/modules/m_version.c
@@ -134,10 +134,6 @@ confopts(struct Client *source_p)
     *p++ = 'T';
 #endif
 
-#ifdef HAVE_LIBZ
-    *p++ = 'Z';
-#endif
-
 #ifdef RB_IPV6
     *p++ = '6';
 #endif

--- a/src/channel.c
+++ b/src/channel.c
@@ -176,7 +176,7 @@ find_channel_membership(struct Channel *chptr, struct Client *client_p)
 const char *
 find_channel_status(struct membership *msptr, int combine)
 {
-    static char buffer[5];
+    static char buffer[6];
     char *p;
 
     p = buffer;

--- a/src/client.c
+++ b/src/client.c
@@ -239,9 +239,6 @@ free_local_client(struct Client *client_p)
     if(IsSSL(client_p))
         ssld_decrement_clicount(client_p->localClient->ssl_ctl);
 
-    if(IsCapable(client_p, CAP_ZIP))
-        ssld_decrement_clicount(client_p->localClient->z_ctl);
-
     rb_bh_free(lclient_heap, client_p->localClient);
     client_p->localClient = NULL;
 }

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -107,7 +107,6 @@ int kline_queued = 0;
 int server_state_foreground = 0;
 int opers_see_all_users = 0;
 int ssl_ok = 0;
-int zlib_ok = 1;
 
 int testing_conf = 0;
 time_t startup_time;

--- a/src/listener.c
+++ b/src/listener.c
@@ -451,6 +451,7 @@ accept_precallback(rb_fde_t *F, struct sockaddr *addr, rb_socklen_t addrlen, voi
     static time_t last_oper_notice = 0;
     int len;
 
+    /* connection on an ssl port, but we cant ssl */
     if(listener->ssl && (!ssl_ok || !get_ssld_count())) {
         rb_close(F);
         return 0;

--- a/src/listener.c
+++ b/src/listener.c
@@ -142,7 +142,7 @@ show_ports(struct Client *source_p)
 #endif
                            IsOperAdmin(source_p) ? listener->name : me.name,
                            listener->ref_count, (listener->active) ? "active" : "disabled",
-                           listener->ssl ? " ssl" : "");
+                           listener->type & SSL_PORT ? " ssl" : "");
     }
 }
 
@@ -284,7 +284,7 @@ find_listener(struct rb_sockaddr_storage *addr)
  * the format "255.255.255.255"
  */
 void
-add_listener(int port, const char *vhost_ip, int family, int ssl, int defer_accept)
+add_listener(int port, const char *vhost_ip, int family, int type, int defer_accept)
 {
     struct Listener *listener;
     struct rb_sockaddr_storage vaddr;
@@ -347,7 +347,7 @@ add_listener(int port, const char *vhost_ip, int family, int ssl, int defer_acce
     }
 
     listener->F = NULL;
-    listener->ssl = ssl;
+    listener->type = type;
     listener->defer_accept = defer_accept;
 
     if(inetport(listener))
@@ -452,7 +452,7 @@ accept_precallback(rb_fde_t *F, struct sockaddr *addr, rb_socklen_t addrlen, voi
     int len;
 
     /* connection on an ssl port, but we cant ssl */
-    if(listener->ssl && (!ssl_ok || !get_ssld_count())) {
+    if(listener->type && !get_ssld_count()) {
         rb_close(F);
         return 0;
     }
@@ -521,7 +521,7 @@ accept_ssld(rb_fde_t *F, struct sockaddr *addr, struct sockaddr *laddr, struct L
         rb_close(F);
         return;
     }
-    ctl = start_ssld_accept(F, xF[1], rb_get_fd(xF[0])); /* this will close F for us */
+    ctl = start_ssld_accept(F, xF[1], rb_get_fd(xF[0]), listener->type); /* this will close F for us */
     add_connection(listener, xF[0], addr, laddr, ctl);
 }
 
@@ -540,7 +540,7 @@ accept_callback(rb_fde_t *F, int status, struct sockaddr *addr, rb_socklen_t add
         return;
     }
 
-    if(listener->ssl)
+    if(listener->type)
         accept_ssld(F, addr, (struct sockaddr *)&lip, listener);
     else
         add_connection(listener, F, addr, (struct sockaddr *)&lip, NULL);

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -837,7 +837,7 @@ conf_set_listen_defer_accept(void *data)
 }
 
 static void
-conf_set_listen_port_both(void *data, int ssl)
+conf_set_listen_port_both(void *data, int type)
 {
     conf_parm_t *args = data;
     for (; args; args = args->next) {
@@ -847,9 +847,9 @@ conf_set_listen_port_both(void *data, int ssl)
             continue;
         }
         if(listener_address == NULL) {
-            add_listener(args->v.number, listener_address, AF_INET, ssl, yy_defer_accept);
+            add_listener(args->v.number, listener_address, AF_INET, type, yy_defer_accept);
 #ifdef RB_IPV6
-            add_listener(args->v.number, listener_address, AF_INET6, ssl, yy_defer_accept);
+            add_listener(args->v.number, listener_address, AF_INET6, type, yy_defer_accept);
 #endif
         } else {
             int family;
@@ -860,7 +860,7 @@ conf_set_listen_port_both(void *data, int ssl)
 #endif
                 family = AF_INET;
 
-            add_listener(args->v.number, listener_address, family, ssl, yy_defer_accept);
+            add_listener(args->v.number, listener_address, family, type, yy_defer_accept);
 
         }
 
@@ -870,13 +870,13 @@ conf_set_listen_port_both(void *data, int ssl)
 static void
 conf_set_listen_port(void *data)
 {
-    conf_set_listen_port_both(data, 0);
+    conf_set_listen_port_both(data, PLAIN_PORT);
 }
 
 static void
 conf_set_listen_sslport(void *data)
 {
-    conf_set_listen_port_both(data, 1);
+    conf_set_listen_port_both(data, SSL_PORT);
 }
 
 static void

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -1250,13 +1250,6 @@ conf_end_connect(struct TopConf *tc)
         return 0;
     }
 
-#ifndef HAVE_LIBZ
-    if(ServerConfCompressed(yy_server)) {
-        conf_report_error("Ignoring connect::flags::compressed -- zlib not available.");
-        yy_server->flags &= ~SERVER_COMPRESSED;
-    }
-#endif
-
     add_server_conf(yy_server);
     rb_dlinkAdd(yy_server, &yy_server->node, &server_conf_list);
 
@@ -1534,18 +1527,7 @@ conf_set_general_stats_i_oper_only(void *data)
 static void
 conf_set_general_compression_level(void *data)
 {
-#ifdef HAVE_LIBZ
-    ConfigFileEntry.compression_level = *(unsigned int *) data;
-
-    if((ConfigFileEntry.compression_level < 1) || (ConfigFileEntry.compression_level > 9)) {
-        conf_report_error
-        ("Invalid general::compression_level %d -- using default.",
-         ConfigFileEntry.compression_level);
-        ConfigFileEntry.compression_level = 0;
-    }
-#else
     conf_report_error("Ignoring general::compression_level -- zlib not available.");
-#endif
 }
 
 static void

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -727,10 +727,6 @@ set_default_conf(void)
     ConfigFileEntry.secret_channels_in_whois = NO;
     ConfigFileEntry.away_interval = 30;
 
-#ifdef HAVE_LIBZ
-    ConfigFileEntry.compression_level = 4;
-#endif
-
     ConfigFileEntry.oper_umodes = UMODE_LOCOPS | UMODE_SERVNOTICE |
                                   UMODE_OPERWALL | UMODE_WALLOP;
     ConfigFileEntry.oper_only_umodes = UMODE_SERVNOTICE;

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -342,11 +342,8 @@ check_server(const char *name, struct Client *client_p)
 
     attach_server_conf(client_p, server_p);
 
-    /* clear ZIP/TB if they support but we dont want them */
-#ifdef HAVE_LIBZ
-    if(!ServerConfCompressed(server_p))
-#endif
-        ClearCap(client_p, CAP_ZIP);
+    /* clear ZIP/TB, no support on our side */
+    ClearCap(client_p, CAP_ZIP);
 
     if(!ServerConfTb(server_p))
         ClearCap(client_p, CAP_TB);
@@ -782,10 +779,6 @@ server_estab(struct Client *client_p)
     if(!rb_set_buffers(client_p->localClient->F, READBUF_SIZE))
         ilog_error("rb_set_buffers failed for server");
 
-    /* Enable compression now */
-    if(IsCapable(client_p, CAP_ZIP)) {
-        start_zlib_session(client_p);
-    }
     sendto_one(client_p, "SVINFO %d %d 0 :%ld", TS_CURRENT, TS_MIN, (long int)rb_current_time());
 
     client_p->servptr = &me;

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -1206,7 +1206,7 @@ serv_connect_ssl_callback(rb_fde_t *F, int status, void *data)
     client_p->localClient->F = xF[0];
     add_to_cli_fd_hash(client_p);
 
-    client_p->localClient->ssl_ctl = start_ssld_connect(F, xF[1], rb_get_fd(xF[0]));
+    client_p->localClient->ssl_ctl = start_ssld_connect(F, xF[1], rb_get_fd(xF[0]), 1 /* SSL_PORT */);
     SetSSL(client_p);
     serv_connect_callback(client_p->localClient->F, RB_OK, client_p);
 }

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -36,9 +36,6 @@
 #include "send.h"
 #include "packet.h"
 
-#define ZIPSTATS_TIME           60
-
-static void collect_zipstats(void *unused);
 static void ssl_read_ctl(rb_fde_t * F, void *data);
 static int ssld_count;
 
@@ -324,38 +321,6 @@ start_ssldaemon(int count, const char *ssl_cert, const char *ssl_private_key, co
 }
 
 static void
-ssl_process_zipstats(ssl_ctl_t * ctl, ssl_ctl_buf_t * ctl_buf)
-{
-    struct Client *server;
-    struct ZipStats *zips;
-    int parc;
-    char *parv[7];
-    parc = rb_string_to_array(ctl_buf->buf, parv, 6);
-    server = find_server(NULL, parv[1]);
-    if(server == NULL || server->localClient == NULL || !IsCapable(server, CAP_ZIP))
-        return;
-    if(server->localClient->zipstats == NULL)
-        server->localClient->zipstats = rb_malloc(sizeof(struct ZipStats));
-
-    zips = server->localClient->zipstats;
-
-    zips->in += strtoull(parv[2], NULL, 10);
-    zips->in_wire += strtoull(parv[3], NULL, 10);
-    zips->out += strtoull(parv[4], NULL, 10);
-    zips->out_wire += strtoull(parv[5], NULL, 10);
-
-    if(zips->in > 0)
-        zips->in_ratio = ((double) (zips->in - zips->in_wire) / (double) zips->in) * 100.00;
-    else
-        zips->in_ratio = 0;
-
-    if(zips->out > 0)
-        zips->out_ratio = ((double) (zips->out - zips->out_wire) / (double) zips->out) * 100.00;
-    else
-        zips->out_ratio = 0;
-}
-
-static void
 ssl_process_dead_fd(ssl_ctl_t * ctl, ssl_ctl_buf_t * ctl_buf)
 {
     struct Client *client_p;
@@ -413,7 +378,7 @@ static void
 ssl_process_cmd_recv(ssl_ctl_t * ctl)
 {
     static const char *cannot_setup_ssl = "ssld cannot setup ssl, check your certificates and private key";
-    static const char *no_ssl_or_zlib = "ssld has neither SSL/TLS or zlib support killing all sslds";
+    static const char *no_ssl = "ssld has no SSL/TLS support killing all sslds";
     rb_dlink_node *ptr, *next;
     ssl_ctl_buf_t *ctl_buf;
     if(ctl->dead)
@@ -430,22 +395,15 @@ ssl_process_cmd_recv(ssl_ctl_t * ctl)
         case 'F':
             ssl_process_certfp(ctl, ctl_buf);
             break;
-        case 'S':
-            ssl_process_zipstats(ctl, ctl_buf);
-            break;
         case 'I':
             ssl_ok = 0;
             ilog(L_MAIN, cannot_setup_ssl);
             sendto_realops_snomask(SNO_GENERAL, L_ALL, cannot_setup_ssl);
         case 'U':
-            zlib_ok = 0;
             ssl_ok = 0;
-            ilog(L_MAIN, no_ssl_or_zlib);
-            sendto_realops_snomask(SNO_GENERAL, L_ALL, no_ssl_or_zlib);
+            ilog(L_MAIN, no_ssl);
+            sendto_realops_snomask(SNO_GENERAL, L_ALL, no_ssl);
             ssl_killall();
-            break;
-        case 'z':
-            zlib_ok = 0;
             break;
         default:
             ilog(L_MAIN, "Received invalid command from ssld: %s", ctl_buf->buf);
@@ -674,125 +632,6 @@ ssld_decrement_clicount(ssl_ctl_t * ctl)
     }
 }
 
-/*
- * what we end up sending to the ssld process for ziplinks is the following
- * Z[ourfd][level][RECVQ]
- * Z = ziplinks command	= buf[0]
- * ourfd = Our end of the socketpair = buf[1..4]
- * level = zip level buf[5]
- * recvqlen = our recvq len = buf[6-7]
- * recvq = any data we read prior to starting ziplinks
- */
-void
-start_zlib_session(void *data)
-{
-    struct Client *server = (struct Client *) data;
-    uint16_t recvqlen;
-    uint8_t level;
-    void *xbuf;
-
-    rb_fde_t *F[2];
-    rb_fde_t *xF1, *xF2;
-    char *buf;
-    char buf2[9];
-    void *recvq_start;
-
-    size_t hdr = (sizeof(uint8_t) * 2) + sizeof(int32_t);
-    size_t len;
-    int cpylen, left;
-
-    server->localClient->event = NULL;
-
-    recvqlen = rb_linebuf_len(&server->localClient->buf_recvq);
-
-    len = recvqlen + hdr;
-
-    if(len > READBUF_SIZE) {
-        sendto_realops_snomask(SNO_GENERAL, L_ALL,
-                               "ssld - attempted to pass message of %zd len, max len %d, giving up",
-                               len, READBUF_SIZE);
-        ilog(L_MAIN, "ssld - attempted to pass message of %zd len, max len %d, giving up", len, READBUF_SIZE);
-        exit_client(server, server, server, "ssld readbuf exceeded");
-        return;
-    }
-
-    buf = rb_malloc(len);
-    level = ConfigFileEntry.compression_level;
-
-    int32_to_buf(&buf[1], rb_get_fd(server->localClient->F));
-    buf[5] = (char) level;
-
-    recvq_start = &buf[6];
-    server->localClient->zipstats = rb_malloc(sizeof(struct ZipStats));
-
-    xbuf = recvq_start;
-    left = recvqlen;
-
-    do {
-        cpylen = rb_linebuf_get(&server->localClient->buf_recvq, xbuf, left, LINEBUF_PARTIAL, LINEBUF_RAW);
-        left -= cpylen;
-        xbuf = (void *) (((uintptr_t) xbuf) + cpylen);
-    } while(cpylen > 0);
-
-    /* Pass the socket to ssld. */
-    *buf = 'Z';
-    if(rb_socketpair(AF_UNIX, SOCK_STREAM, 0, &xF1, &xF2, "Initial zlib socketpairs") == -1) {
-        sendto_realops_snomask(SNO_GENERAL, L_ALL, "Error creating zlib socketpair - %s", strerror(errno));
-        ilog(L_MAIN, "Error creating zlib socketpairs - %s", strerror(errno));
-        exit_client(server, server, server, "Error creating zlib socketpair");
-        return;
-    }
-
-    if(IsSSL(server)) {
-        /* tell ssld the new connid for the ssl part*/
-        buf2[0] = 'Y';
-        int32_to_buf(&buf2[1], rb_get_fd(server->localClient->F));
-        int32_to_buf(&buf2[5], rb_get_fd(xF2));
-        ssl_cmd_write_queue(server->localClient->ssl_ctl, NULL, 0, buf2, sizeof(buf2));
-    }
-
-
-    F[0] = server->localClient->F;
-    F[1] = xF1;
-    del_from_cli_fd_hash(server);
-    server->localClient->F = xF2;
-    /* need to redo as what we did before isn't valid now */
-    int32_to_buf(&buf[1], rb_get_fd(server->localClient->F));
-    add_to_cli_fd_hash(server);
-
-    server->localClient->z_ctl = which_ssld();
-    server->localClient->z_ctl->cli_count++;
-    ssl_cmd_write_queue(server->localClient->z_ctl, F, 2, buf, len);
-    rb_free(buf);
-}
-
-static void
-collect_zipstats(void *unused)
-{
-    rb_dlink_node *ptr;
-    struct Client *target_p;
-    char buf[sizeof(uint8_t) + sizeof(int32_t) + HOSTLEN];
-    void *odata;
-    size_t len;
-    int32_t id;
-
-    buf[0] = 'S';
-    odata = buf + sizeof(uint8_t) + sizeof(int32_t);
-
-    RB_DLINK_FOREACH(ptr, serv_list.head) {
-        target_p = ptr->data;
-        if(IsCapable(target_p, CAP_ZIP)) {
-            len = sizeof(uint8_t) + sizeof(uint32_t);
-
-            id = rb_get_fd(target_p->localClient->F);
-            int32_to_buf(&buf[1], rb_get_fd(target_p->localClient->F));
-            rb_strlcpy(odata, target_p->name, (sizeof(buf) - len));
-            len += strlen(odata) + 1;	/* Get the \0 as well */
-            ssl_cmd_write_queue(target_p->localClient->z_ctl, NULL, 0, buf, len);
-        }
-    }
-}
-
 static void
 cleanup_dead_ssl(void *unused)
 {
@@ -815,6 +654,5 @@ get_ssld_count(void)
 void
 init_ssld(void)
 {
-    rb_event_addish("collect_zipstats", collect_zipstats, NULL, ZIPSTATS_TIME);
     rb_event_addish("cleanup_dead_ssld", cleanup_dead_ssl, NULL, 1200);
 }

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -424,6 +424,7 @@ ssl_read_ctl(rb_fde_t * F, void *data)
     rb_setselect(ctl->F, RB_SELECT_READ, ssl_read_ctl, ctl);
 }
 
+/* Return the ssld with the fewest clients */
 static ssl_ctl_t *
 which_ssld(void)
 {

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -363,9 +363,6 @@ ssl_process_cmd_recv(ssl_ctl_t * ctl)
     RB_DLINK_FOREACH_SAFE(ptr, next, ctl->readq.head) {
         ctl_buf = ptr->data;
         switch (*ctl_buf->buf) {
-        case 'N':
-            ssl_ok = 0;	/* ssld says it can't do ssl/tls */
-            break;
         case 'D':
             ssl_process_dead_fd(ctl, ctl_buf);
             break;

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -561,16 +561,17 @@ send_new_ssl_certs(const char *ssl_cert, const char *ssl_private_key, const char
 
 
 ssl_ctl_t *
-start_ssld_accept(rb_fde_t * sslF, rb_fde_t * plainF, int32_t id)
+start_ssld_accept(rb_fde_t * sslF, rb_fde_t * plainF, int32_t id, int32_t type)
 {
     rb_fde_t *F[2];
     ssl_ctl_t *ctl;
-    char buf[5];
+    char buf[9];
     F[0] = sslF;
     F[1] = plainF;
 
     buf[0] = 'A';
     int32_to_buf(&buf[1], id);
+    int32_to_buf(&buf[4], type);
     ctl = which_ssld();
     ctl->cli_count++;
     ssl_cmd_write_queue(ctl, F, 2, buf, sizeof(buf));
@@ -578,17 +579,17 @@ start_ssld_accept(rb_fde_t * sslF, rb_fde_t * plainF, int32_t id)
 }
 
 ssl_ctl_t *
-start_ssld_connect(rb_fde_t * sslF, rb_fde_t * plainF, int32_t id)
+start_ssld_connect(rb_fde_t * sslF, rb_fde_t * plainF, int32_t id, int32_t type)
 {
     rb_fde_t *F[2];
     ssl_ctl_t *ctl;
-    char buf[5];
+    char buf[9];
     F[0] = sslF;
     F[1] = plainF;
 
     buf[0] = 'C';
     int32_to_buf(&buf[1], id);
-
+    int32_to_buf(&buf[4], type);
     ctl = which_ssld();
     ctl->cli_count++;
     ssl_cmd_write_queue(ctl, F, 2, buf, sizeof(buf));

--- a/ssld/Makefile.in
+++ b/ssld/Makefile.in
@@ -29,9 +29,7 @@ PACKAGE_TARNAME = @PACKAGE_TARNAME@
 
 PROGRAM_PREFIX   = @PROGRAM_PREFIX@
 
-ZIP_LIB		= @ZLIB_LD@
-
-IRCDLIBS	= @MODULES_LIBS@ -L../libratbox/src/.libs -lratbox @LIBS@ $(SSL_LIBS) $(ZIP_LIB)
+IRCDLIBS	= @MODULES_LIBS@ -L../libratbox/src/.libs -lratbox @LIBS@ $(SSL_LIBS)
 
 INCLUDES        = -I. -I../include -I../libratbox/include $(SSL_INCLUDES)
 CPPFLAGS        = ${INCLUDES} @CPPFLAGS@

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -71,15 +71,13 @@
  *
  * Certificate fingerprint for sasl authentication
  *
- * Nossl/I am useless/cannot initialize:
+ * I am useless/cannot initialize:
  *  u8
- * ['N'] 
  * ['U']
  * ['I']
  *
  * indicates that ssld can't do ssl (?)
- * 'N' unknown
- * 'U' ssld compiled without ssl support
+ * 'U' libratbox reports no ssl support
  * 'I' configuration error
  **/
 
@@ -206,7 +204,6 @@ static void mod_cmd_write_queue(mod_ctl_t * ctl, const void *data, size_t len);
 static const char *remote_closed = "Remote host closed the connection";
 static int ssl_ok;
 
-static void send_nossl_support(mod_ctl_t * ctl);
 static void send_i_am_useless(mod_ctl_t * ctl);
 static void send_config_error(mod_ctl_t * ctl);
 
@@ -697,13 +694,6 @@ ssl_new_keys(mod_ctl_t * ctl, mod_ctl_buf_t * ctl_buf)
 }
 
 static void
-send_nossl_support(mod_ctl_t * ctl)
-{
-    static const char *nossl_cmd = "N";
-    mod_cmd_write_queue(ctl, nossl_cmd, strlen(nossl_cmd));
-}
-
-static void
 send_i_am_useless(mod_ctl_t * ctl)
 {
     static const char *useless = "U";
@@ -877,8 +867,6 @@ main(int argc, char **argv)
         exit(1);
     }
 
-    if(!ssl_ok)
-        send_nossl_support(mod_ctl);
     rb_lib_loop(0);
     return 0;
 }

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -1,5 +1,5 @@
 /*
- *  ssld.c: The ircd-ratbox ssl/zlib helper daemon thingy
+ *  ssld.c: The ircd-ratbox ssl helper daemon thingy
  *  Copyright (C) 2007 Aaron Sethman <androsyn@ratbox.org>
  *  Copyright (C) 2007 ircd-ratbox development team
  *
@@ -23,10 +23,6 @@
 
 
 #include "stdinc.h"
-
-#ifdef HAVE_LIBZ
-#include <zlib.h>
-#endif
 
 #define MAXPASSFD 4
 #ifndef READBUF_SIZE
@@ -68,9 +64,6 @@ uint16_to_buf(char *buf, uint16_t x)
 
 
 static char inbuf[READBUF_SIZE];
-#ifdef HAVE_LIBZ
-static char outbuf[READBUF_SIZE];
-#endif
 
 typedef struct _mod_ctl_buf {
     rb_dlink_node node;
@@ -92,13 +85,6 @@ typedef struct _mod_ctl {
 static mod_ctl_t *mod_ctl;
 
 
-#ifdef HAVE_LIBZ
-typedef struct _zlib_stream {
-    z_stream instream;
-    z_stream outstream;
-} zlib_stream_t;
-#endif
-
 typedef struct _conn {
     rb_dlink_node node;
     mod_ctl_t *ctl;
@@ -118,36 +104,32 @@ typedef struct _conn {
 } conn_t;
 
 #define FLAG_SSL	0x01
-#define FLAG_ZIP	0x02
+//define FLAG_ZIP	0x02
 #define FLAG_CORK	0x04
 #define FLAG_DEAD	0x08
 #define FLAG_SSL_W_WANTS_R 0x10	/* output needs to wait until input possible */
 #define FLAG_SSL_R_WANTS_W 0x20	/* input needs to wait until output possible */
-#define FLAG_ZIPSSL	0x40
 
 #define IsSSL(x) ((x)->flags & FLAG_SSL)
-#define IsZip(x) ((x)->flags & FLAG_ZIP)
+//define IsZip(x) ((x)->flags & FLAG_ZIP)
 #define IsCork(x) ((x)->flags & FLAG_CORK)
 #define IsDead(x) ((x)->flags & FLAG_DEAD)
 #define IsSSLWWantsR(x) ((x)->flags & FLAG_SSL_W_WANTS_R)
 #define IsSSLRWantsW(x) ((x)->flags & FLAG_SSL_R_WANTS_W)
-#define IsZipSSL(x)	((x)->flags & FLAG_ZIPSSL)
 
 #define SetSSL(x) ((x)->flags |= FLAG_SSL)
-#define SetZip(x) ((x)->flags |= FLAG_ZIP)
+//define SetZip(x) ((x)->flags |= FLAG_ZIP)
 #define SetCork(x) ((x)->flags |= FLAG_CORK)
 #define SetDead(x) ((x)->flags |= FLAG_DEAD)
 #define SetSSLWWantsR(x) ((x)->flags |= FLAG_SSL_W_WANTS_R)
 #define SetSSLRWantsW(x) ((x)->flags |= FLAG_SSL_R_WANTS_W)
-#define SetZipSSL(x)	((x)->flags |= FLAG_ZIPSSL)
 
 #define ClearSSL(x) ((x)->flags &= ~FLAG_SSL)
-#define ClearZip(x) ((x)->flags &= ~FLAG_ZIP)
+//define ClearZip(x) ((x)->flags &= ~FLAG_ZIP)
 #define ClearCork(x) ((x)->flags &= ~FLAG_CORK)
 #define ClearDead(x) ((x)->flags &= ~FLAG_DEAD)
 #define ClearSSLWWantsR(x) ((x)->flags &= ~FLAG_SSL_W_WANTS_R)
 #define ClearSSLRWantsW(x) ((x)->flags &= ~FLAG_SSL_R_WANTS_W)
-#define ClearZipSSL(x)	((x)->flags &= ~FLAG_ZIPSSL)
 
 #define NO_WAIT 0x0
 #define WAIT_PLAIN 0x1
@@ -171,26 +153,6 @@ static void conn_plain_read_shutdown_cb(rb_fde_t *fd, void *data);
 static void mod_cmd_write_queue(mod_ctl_t * ctl, const void *data, size_t len);
 static const char *remote_closed = "Remote host closed the connection";
 static int ssl_ok;
-#ifdef HAVE_LIBZ
-static int zlib_ok = 1;
-#else
-static int zlib_ok = 0;
-#endif
-
-
-#ifdef HAVE_LIBZ
-static void *
-ssld_alloc(void *unused, size_t count, size_t size)
-{
-    return rb_malloc(count * size);
-}
-
-static void
-ssld_free(void *unused, void *ptr)
-{
-    rb_free(ptr);
-}
-#endif
 
 static conn_t *
 conn_find_by_id(int32_t id)
@@ -218,13 +180,6 @@ free_conn(conn_t * conn)
 {
     rb_free_rawbuffer(conn->modbuf_out);
     rb_free_rawbuffer(conn->plainbuf_out);
-#ifdef HAVE_LIBZ
-    if(IsZip(conn)) {
-        zlib_stream_t *stream = conn->stream;
-        inflateEnd(&stream->instream);
-        deflateEnd(&stream->outstream);
-    }
-#endif
     rb_free(conn);
 }
 
@@ -256,7 +211,7 @@ close_conn(conn_t * conn, int wait_plain, const char *fmt, ...)
     rb_close(conn->mod_fd);
     SetDead(conn);
 
-    if(conn->id >= 0 && !IsZipSSL(conn))
+    if(conn->id >= 0)
         rb_dlinkDelete(&conn->node, connid_hash(conn->id));
 
     if(!wait_plain || fmt == NULL) {
@@ -391,72 +346,6 @@ mod_cmd_write_queue(mod_ctl_t * ctl, const void *data, size_t len)
     mod_write_ctl(ctl->F, ctl);
 }
 
-#ifdef HAVE_LIBZ
-static void
-common_zlib_deflate(conn_t * conn, void *buf, size_t len)
-{
-    int ret, have;
-    z_stream *outstream = &((zlib_stream_t *) conn->stream)->outstream;
-    outstream->next_in = buf;
-    outstream->avail_in = len;
-    outstream->next_out = (Bytef *) outbuf;
-    outstream->avail_out = sizeof(outbuf);
-
-    ret = deflate(outstream, Z_SYNC_FLUSH);
-    if(ret != Z_OK) {
-        /* deflate error */
-        close_conn(conn, WAIT_PLAIN, "Deflate failed: %s", zError(ret));
-        return;
-    }
-    if(outstream->avail_out == 0) {
-        /* avail_out empty */
-        close_conn(conn, WAIT_PLAIN, "error compressing data, avail_out == 0");
-        return;
-    }
-    if(outstream->avail_in != 0) {
-        /* avail_in isn't empty... */
-        close_conn(conn, WAIT_PLAIN, "error compressing data, avail_in != 0");
-        return;
-    }
-    have = sizeof(outbuf) - outstream->avail_out;
-    conn_mod_write(conn, outbuf, have);
-}
-
-static void
-common_zlib_inflate(conn_t * conn, void *buf, size_t len)
-{
-    int ret, have = 0;
-    ((zlib_stream_t *) conn->stream)->instream.next_in = buf;
-    ((zlib_stream_t *) conn->stream)->instream.avail_in = len;
-    ((zlib_stream_t *) conn->stream)->instream.next_out = (Bytef *) outbuf;
-    ((zlib_stream_t *) conn->stream)->instream.avail_out = sizeof(outbuf);
-
-    while(((zlib_stream_t *) conn->stream)->instream.avail_in) {
-        ret = inflate(&((zlib_stream_t *) conn->stream)->instream, Z_NO_FLUSH);
-        if(ret != Z_OK) {
-            if(!strncmp("ERROR ", buf, 6)) {
-                close_conn(conn, WAIT_PLAIN, "Received uncompressed ERROR");
-                return;
-            }
-            close_conn(conn, WAIT_PLAIN, "Inflate failed: %s", zError(ret));
-            return;
-        }
-        have = sizeof(outbuf) - ((zlib_stream_t *) conn->stream)->instream.avail_out;
-
-        if(((zlib_stream_t *) conn->stream)->instream.avail_in) {
-            conn_plain_write(conn, outbuf, have);
-            have = 0;
-            ((zlib_stream_t *) conn->stream)->instream.next_out = (Bytef *) outbuf;
-            ((zlib_stream_t *) conn->stream)->instream.avail_out = sizeof(outbuf);
-        }
-    }
-    if(have == 0)
-        return;
-
-    conn_plain_write(conn, outbuf, have);
-}
-#endif
-
 static int
 plain_check_cork(conn_t * conn)
 {
@@ -504,13 +393,8 @@ conn_plain_read_cb(rb_fde_t *fd, void *data)
             return;
         }
         conn->plain_in += length;
+        conn_mod_write(conn, inbuf, length);
 
-#ifdef HAVE_LIBZ
-        if(IsZip(conn))
-            common_zlib_deflate(conn, inbuf, length);
-        else
-#endif
-            conn_mod_write(conn, inbuf, length);
         if(IsDead(conn))
             return;
         if(plain_check_cork(conn))
@@ -592,12 +476,7 @@ conn_mod_read_cb(rb_fde_t *fd, void *data)
             return;
         }
         conn->mod_in += length;
-#ifdef HAVE_LIBZ
-        if(IsZip(conn))
-            common_zlib_inflate(conn, inbuf, length);
-        else
-#endif
-            conn_plain_write(conn, inbuf, length);
+        conn_plain_write(conn, inbuf, length);
     }
 }
 
@@ -740,105 +619,6 @@ ssl_process_connect(mod_ctl_t * ctl, mod_ctl_buf_t * ctlb)
 }
 
 static void
-process_stats(mod_ctl_t * ctl, mod_ctl_buf_t * ctlb)
-{
-    char outstat[512];
-    conn_t *conn;
-    const char *odata;
-    int32_t id;
-
-    id = buf_to_int32(&ctlb->buf[1]);
-
-    if(id < 0)
-        return;
-
-    odata = &ctlb->buf[5];
-    conn = conn_find_by_id(id);
-
-    if(conn == NULL)
-        return;
-
-    rb_snprintf(outstat, sizeof(outstat), "S %s %llu %llu %llu %llu", odata,
-                conn->plain_out, conn->mod_in, conn->plain_in, conn->mod_out);
-    conn->plain_out = 0;
-    conn->plain_in = 0;
-    conn->mod_in = 0;
-    conn->mod_out = 0;
-    mod_cmd_write_queue(ctl, outstat, strlen(outstat) + 1);	/* +1 is so we send the \0 as well */
-}
-
-static void
-change_connid(mod_ctl_t *ctl, mod_ctl_buf_t *ctlb)
-{
-    int32_t id = buf_to_int32(&ctlb->buf[1]);
-    int32_t newid = buf_to_int32(&ctlb->buf[5]);
-    conn_t *conn = conn_find_by_id(id);
-    if(conn->id >= 0)
-        rb_dlinkDelete(&conn->node, connid_hash(conn->id));
-    SetZipSSL(conn);
-    conn->id = newid;
-}
-
-#ifdef HAVE_LIBZ
-static void
-zlib_process(mod_ctl_t * ctl, mod_ctl_buf_t * ctlb)
-{
-    uint8_t level;
-    size_t recvqlen;
-    size_t hdr = (sizeof(uint8_t) * 2) + sizeof(int32_t);
-    void *recvq_start;
-    z_stream *instream, *outstream;
-    conn_t *conn;
-    int32_t id;
-
-    conn = make_conn(ctl, ctlb->F[0], ctlb->F[1]);
-    if(rb_get_type(conn->mod_fd) == RB_FD_UNKNOWN)
-        rb_set_type(conn->mod_fd, RB_FD_SOCKET);
-
-    if(rb_get_type(conn->plain_fd) == RB_FD_UNKNOWN)
-        rb_set_type(conn->plain_fd, RB_FD_SOCKET);
-
-    id = buf_to_int32(&ctlb->buf[1]);
-    conn_add_id_hash(conn, id);
-
-    level = (uint8_t)ctlb->buf[5];
-
-    recvqlen = ctlb->buflen - hdr;
-    recvq_start = &ctlb->buf[6];
-
-    SetZip(conn);
-    conn->stream = rb_malloc(sizeof(zlib_stream_t));
-    instream = &((zlib_stream_t *) conn->stream)->instream;
-    outstream = &((zlib_stream_t *) conn->stream)->outstream;
-
-    instream->total_in = 0;
-    instream->total_out = 0;
-    instream->zalloc = (alloc_func) ssld_alloc;
-    instream->zfree = (free_func) ssld_free;
-    instream->data_type = Z_ASCII;
-    inflateInit(&((zlib_stream_t *) conn->stream)->instream);
-
-    outstream->total_in = 0;
-    outstream->total_out = 0;
-    outstream->zalloc = (alloc_func) ssld_alloc;
-    outstream->zfree = (free_func) ssld_free;
-    outstream->data_type = Z_ASCII;
-
-    if(level > 9)
-        level = Z_DEFAULT_COMPRESSION;
-
-    deflateInit(&((zlib_stream_t *) conn->stream)->outstream, level);
-    if(recvqlen > 0)
-        common_zlib_inflate(conn, recvq_start, recvqlen);
-
-    conn_mod_read_cb(conn->mod_fd, conn);
-    conn_plain_read_cb(conn->plain_fd, conn);
-    return;
-
-}
-#endif
-
-static void
 init_prng(mod_ctl_t * ctl, mod_ctl_buf_t * ctl_buf)
 {
     char *path;
@@ -898,23 +678,6 @@ send_i_am_useless(mod_ctl_t * ctl)
 }
 
 static void
-send_nozlib_support(mod_ctl_t * ctl, mod_ctl_buf_t * ctlb)
-{
-    static const char *nozlib_cmd = "z";
-    conn_t *conn;
-    int32_t id;
-    if(ctlb != NULL) {
-        conn = make_conn(ctl, ctlb->F[0], ctlb->F[1]);
-        id = buf_to_int32(&ctlb->buf[1]);
-
-        if(id >= 0)
-            conn_add_id_hash(conn, id);
-        close_conn(conn, WAIT_PLAIN, "libratbox reports no zlib support");
-    }
-    mod_cmd_write_queue(ctl, nozlib_cmd, strlen(nozlib_cmd));
-}
-
-static void
 mod_process_cmd_recv(mod_ctl_t * ctl)
 {
     rb_dlink_node *ptr, *next;
@@ -962,33 +725,7 @@ mod_process_cmd_recv(mod_ctl_t * ctl)
         case 'I':
             init_prng(ctl, ctl_buf);
             break;
-        case 'S': {
-            process_stats(ctl, ctl_buf);
-            break;
-        }
-        case 'Y': {
-            change_connid(ctl, ctl_buf);
-            break;
-        }
 
-#ifdef HAVE_LIBZ
-        case 'Z': {
-            if (ctl_buf->nfds != 2 || ctl_buf->buflen < 6) {
-                cleanup_bad_message(ctl, ctl_buf);
-                break;
-            }
-
-            /* just zlib only */
-            zlib_process(ctl, ctl_buf);
-            break;
-        }
-#else
-
-        case 'Z':
-            send_nozlib_support(ctl, ctl_buf);
-            break;
-
-#endif
         default:
             break;
             /* Log unknown commands */
@@ -1132,7 +869,7 @@ main(int argc, char **argv)
     rb_event_add("check_handshake_flood", check_handshake_flood, NULL, 10);
     read_pipe_ctl(mod_ctl->F_pipe, NULL);
     mod_read_ctl(mod_ctl->F, mod_ctl);
-    if(!zlib_ok && !ssl_ok) {
+    if(!ssl_ok) {
         /* this is really useless... */
         send_i_am_useless(mod_ctl);
         /* sleep until the ircd kills us */
@@ -1140,8 +877,6 @@ main(int argc, char **argv)
         exit(1);
     }
 
-    if(!zlib_ok)
-        send_nozlib_support(mod_ctl, NULL);
     if(!ssl_ok)
         send_nossl_support(mod_ctl, NULL);
     rb_lib_loop(0);

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -433,14 +433,10 @@ conn_plain_read_cb(rb_fde_t *fd, void *data)
     if(conn == NULL)
         return;
 
-    if(IsDead(conn))
-        return;
-
-    if(plain_check_cork(conn))
-        return;
-
     while(1) {
         if(IsDead(conn))
+            return;
+        if(plain_check_cork(conn))
             return;
 
         length = rb_read(conn->plain_fd, inbuf, sizeof(inbuf));
@@ -457,11 +453,6 @@ conn_plain_read_cb(rb_fde_t *fd, void *data)
         }
         conn->plain_in += length;
         conn_mod_write(conn, inbuf, length);
-
-        if(IsDead(conn))
-            return;
-        if(plain_check_cork(conn))
-            return;
     }
 }
 
@@ -505,8 +496,6 @@ conn_mod_read_cb(rb_fde_t *fd, void *data)
     if(IsSSLRWantsW(conn)) {
         ClearSSLRWantsW(conn);
         conn_mod_write_sendq(conn->mod_fd, conn);
-        if(IsDead(conn))
-            return;
     }
 
     while(1) {

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -159,7 +159,6 @@ typedef struct _conn {
     unsigned long long plain_in;
     unsigned long long plain_out;
     uint8_t flags;
-    void *stream;
 } conn_t;
 
 /* Duplicated in listener.h */
@@ -305,7 +304,6 @@ make_conn(mod_ctl_t * ctl, rb_fde_t *mod_fd, rb_fde_t *plain_fd)
     conn->mod_fd = mod_fd;
     conn->plain_fd = plain_fd;
     conn->id = -1;
-    conn->stream = NULL;
     rb_set_nb(mod_fd);
     rb_set_nb(plain_fd);
     return conn;

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -350,9 +350,12 @@ conn_mod_write_sendq(rb_fde_t *fd, void *data)
     while((retlen = rb_rawbuf_flush(conn->modbuf_out, fd)) > 0)
         conn->mod_out += retlen;
 
-    if(retlen == 0 || (retlen < 0 && !rb_ignore_errno(errno))) {
-        if(retlen == 0)
-            close_conn(conn, WAIT_PLAIN, "%s", remote_closed);
+    if(retlen == 0) {
+        close_conn(conn, WAIT_PLAIN, "%s", remote_closed);
+        return;
+    }
+
+    if(retlen < 0 && !rb_ignore_errno(errno)) {
         if(retlen == RB_RW_SSL_ERROR)
             err = rb_get_ssl_strerror(conn->mod_fd);
         else
@@ -468,16 +471,16 @@ conn_plain_read_shutdown_cb(rb_fde_t *fd, void *data)
     while(1) {
         length = rb_read(conn->plain_fd, inbuf, sizeof(inbuf));
 
-        if(length == 0 || (length < 0 && !rb_ignore_errno(errno))) {
-            rb_close(conn->plain_fd);
-            rb_dlinkAdd(conn, &conn->node, &dead_list);
-            return;
-        }
+        if(length > 0)
+            continue;
 
-        if(length < 0) {
+        if(length < 0 && rb_ignore_errno(errno)) {
             rb_setselect(conn->plain_fd, RB_SELECT_READ, conn_plain_read_shutdown_cb, conn);
             return;
         }
+
+        rb_close(conn->plain_fd);
+        rb_dlinkAdd(conn, &conn->node, &dead_list);
     }
 }
 
@@ -504,12 +507,12 @@ conn_mod_read_cb(rb_fde_t *fd, void *data)
 
         length = rb_read(conn->mod_fd, inbuf, sizeof(inbuf));
 
-        if(length == 0 || (length < 0 && !rb_ignore_errno(errno))) {
-            if(length == 0) {
-                close_conn(conn, WAIT_PLAIN, "%s", remote_closed);
-                return;
-            }
+        if(length == 0) {
+            close_conn(conn, WAIT_PLAIN, "%s", remote_closed);
+            return;
+        }
 
+        if((length < 0 && !rb_ignore_errno(errno))) {
             if(length == RB_RW_SSL_ERROR)
                 err = rb_get_ssl_strerror(conn->mod_fd);
             else

--- a/testsuite/astyle/check_style.sh
+++ b/testsuite/astyle/check_style.sh
@@ -56,10 +56,8 @@ do
 		continue
 	fi
 
-	if [[ $(astyle --style=linux --mode=c -n $file 2>&1 | cut -f1 -d' ') = "Unchanged" ]]
+	if [[ $(astyle --style=linux --mode=c -n $file 2>&1 | cut -f1 -d' ') != "Unchanged" ]]
 	then
-		echo "$file passed coding standards"
-	else
 		echo "$file is not at coding standards."
 		code=1
 	fi

--- a/testsuite/astyle/check_style.sh
+++ b/testsuite/astyle/check_style.sh
@@ -4,6 +4,8 @@ cd ../..
 
 code=0
 
+command -v astyle >/dev/null 2>&1 || { echo "astyle not found"; exit 1; }
+
 for file in $(find **/*.c)
 do
 	if [[ $file = "bandb/sqlite3.c" ]]

--- a/testsuite/astyle/check_style.sh
+++ b/testsuite/astyle/check_style.sh
@@ -2,6 +2,8 @@
 
 cd ../..
 
+code=0
+
 for file in $(find **/*.c)
 do
 	if [[ $file = "bandb/sqlite3.c" ]]
@@ -59,6 +61,8 @@ do
 		echo "$file passed coding standards"
 	else
 		echo "$file is not at coding standards."
-		exit 1
+		code=1
 	fi
 done
+
+exit $code


### PR DESCRIPTION
this work was initially intended for adding websockets to ssld, i've since dropped my plans to do that.

These are the changes i've made to ssld and the rest of the codebase to ease adding a new type of connection to ssld, as well as cleaning up the code a little.

bigest remaining block to websockets and re-implementing ziplinks is the fact that libratbox does a poor job of hiding ssl, requiring a bunch of boilerplate around any instance of rb_read and rb_write, buffering, and perhaps emulating a read() (depending on what libz needs), which is more code than i wanted to write.