### PR TITLE
Add channel/user message hooking

### DIFF
--- a/doc/example.conf
+++ b/doc/example.conf
@@ -18,6 +18,8 @@ loadmodule "extensions/chm_operonly.so";
 #loadmodule "extensions/chm_quietunreg_compat.so";
 #loadmodule "extensions/chm_sslonly_compat.so";
 #loadmodule "extensions/createauthonly.so";
+#loadmodule "extensions/chm_nocaps.c";
+#loadmodule 'extensions/chm_norepeat.c"
 loadmodule "extensions/extb_account.so";
 loadmodule "extensions/extb_canjoin.so";
 loadmodule "extensions/extb_channel.so";

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -87,6 +87,8 @@ loadmodule "extensions/chm_operonly.so";
 #loadmodule "extensions/chm_operonly_compat.so";
 #loadmodule "extensions/chm_quietunreg_compat.so";
 #loadmodule "extensions/chm_sslonly_compat.so";
+#loadmodule "extensions/chm_nocaps.c";
+#loadmodule 'extensions/chm_norepeat.c"
 #loadmodule "extensions/createauthonly.so";
 loadmodule "extensions/extb_account.so";
 loadmodule "extensions/extb_canjoin.so";

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS = -I../include -I../libratbox/include
 extensiondir=@moduledir@/extensions
 
 extension_DATA = chm_adminonly.so         \
+                 chm_norepeat.so          \
                  chm_operonly_compat.so   \
                  chm_operonly.so          \
                  chm_quietunreg_compat.so \

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -5,7 +5,8 @@ AM_CPPFLAGS = -I../include -I../libratbox/include
 
 extensiondir=@moduledir@/extensions
 
-extension_DATA = chm_adminonly.so         \
+extension_DATA = block_invalid_utf8.so    \
+                 chm_adminonly.so         \
                  chm_norepeat.so          \
                  chm_operonly_compat.so   \
                  chm_operonly.so          \

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -7,6 +7,7 @@ extensiondir=@moduledir@/extensions
 
 extension_DATA = block_invalid_utf8.so    \
                  chm_adminonly.so         \
+                 chm_nocaps.so            \
                  chm_norepeat.so          \
                  chm_operonly_compat.so   \
                  chm_operonly.so          \

--- a/extensions/block_invalid_utf8.c
+++ b/extensions/block_invalid_utf8.c
@@ -31,7 +31,7 @@
 #include "s_user.h"
 #include "s_serv.h"
 #include "numeric.h"
-#include "chmode.h"
+#include "supported.h"
 #include "inline/stringops.h"
 
 static void block_invalid_utf8_process(hook_data_privmsg_channel *);
@@ -75,7 +75,7 @@ block_invalid_utf8_process(hook_data_privmsg_channel *data)
     if(!is_utf8(data->text)) {
         sendto_one_numeric(data->source_p,
                            ERR_CANNOTSENDTOCHAN,
-                           form_str(ERR_CANNOTSENDTOCHAN),
+                           "%s :Cannot send to channel - Your message was badly formatted UTF-8 and this network enforces valid UTF-8",
                            data->chptr->chname);
         data->approved = ERR_CANNOTSENDTOCHAN;
         return;
@@ -85,12 +85,15 @@ block_invalid_utf8_process(hook_data_privmsg_channel *data)
 static int
 _modinit(void)
 {
+    add_isupport("CHARSET", isupport_string, "UTF-8");
+
     return 0;
 }
 
 static void
 _moddeinit(void)
 {
+    delete_isupport("CHARSET");
 }
 
 DECLARE_MODULE_AV1(block_invalid_utf8, _modinit, _moddeinit, NULL, NULL, block_invalid_utf8_hfnlist, "$Revision$");

--- a/extensions/block_invalid_utf8.c
+++ b/extensions/block_invalid_utf8.c
@@ -1,0 +1,96 @@
+/*
+ *
+ * Elemental-IRCd: the ircd of the people
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice is present in all copies.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdbool.h>
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "chmode.h"
+#include "inline/stringops.h"
+
+static void block_invalid_utf8_process(hook_data_privmsg_channel *);
+
+int is_utf8(const char* data)
+{
+    int remaining_continuations = 0;
+    int i = 0;
+
+    while (data[i]) {
+        if(remaining_continuations > 0) {
+            if((data[i] & 0x80) > 0 && (~data[i] & 0x40) > 0)
+                remaining_continuations--;
+            else return false;
+        } else {
+            if((data[i] & 0x80) > 0) {
+                int ones = __builtin_clz(((int)~data[i]) & 0xFF) - __builtin_clz(0x000000FF);
+                if(ones == 1 || ones > 4) return false;
+                remaining_continuations = ones - 1;
+            }
+        }
+
+        i++;
+    }
+    return remaining_continuations == 0;
+}
+
+mapi_hfn_list_av1 block_invalid_utf8_hfnlist[] = {
+    { "privmsg_channel", (hookfn) block_invalid_utf8_process },
+    { NULL, NULL }
+};
+
+static void
+block_invalid_utf8_process(hook_data_privmsg_channel *data)
+{
+    /* don't waste CPU if message is already blocked */
+    if (data->approved) {
+        return;
+    }
+
+    if(!is_utf8(data->text)) {
+        sendto_one_numeric(data->source_p,
+                           ERR_CANNOTSENDTOCHAN,
+                           form_str(ERR_CANNOTSENDTOCHAN),
+                           data->chptr->chname);
+        data->approved = ERR_CANNOTSENDTOCHAN;
+        return;
+    }
+}
+
+static int
+_modinit(void)
+{
+    return 0;
+}
+
+static void
+_moddeinit(void)
+{
+}
+
+DECLARE_MODULE_AV1(block_invalid_utf8, _modinit, _moddeinit, NULL, NULL, block_invalid_utf8_hfnlist, "$Revision$");

--- a/extensions/block_invalid_utf8.c
+++ b/extensions/block_invalid_utf8.c
@@ -36,7 +36,8 @@
 
 static void block_invalid_utf8_process(hook_data_privmsg_channel *);
 
-int is_utf8(const char* data)
+static int
+is_utf8(const char* data)
 {
     int remaining_continuations = 0;
     int i = 0;

--- a/extensions/chm_nocaps.c
+++ b/extensions/chm_nocaps.c
@@ -1,0 +1,103 @@
+/*
+ * Elemental-IRCd
+ * chm_nocaps: blocks capsing messages (+K mode).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice is present in all copies.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "chmode.h"
+#include "inline/stringops.h"
+
+static unsigned int mode_nocaps;
+
+static void chm_nocaps_process(hook_data_privmsg_channel *);
+
+mapi_hfn_list_av1 chm_nocaps_hfnlist[] = {
+    { "privmsg_channel", (hookfn) chm_nocaps_process },
+    { NULL, NULL }
+};
+
+static void
+chm_nocaps_process(hook_data_privmsg_channel *data)
+{
+    char text2[BUFSIZE];
+    size_t contor;
+    int caps = 0;
+    int len = 0;
+
+    struct membership *msptr = find_channel_membership(data->chptr, data->source_p);
+
+    /* don't waste CPU if message is already blocked */
+    if (data->approved) {
+        return;
+    }
+
+    if (strlen(data->text) > 10 &&
+        data->chptr->mode.mode & mode_nocaps &&
+        (!ConfigChannel.exempt_cmode_G || !is_any_op(msptr))) {
+        rb_strlcpy(text2, data->text, BUFSIZE);
+        strip_unprintable(text2);
+
+        // Don't count the "ACTION" part of action as part of the message --SnoFox
+        if (data->msgtype != MESSAGE_TYPE_NOTICE && *data->text == '\001' &&
+            !strncasecmp(data->text + 1, "ACTION ", 7)) {
+            contor = 7;
+        } else {
+            contor = 0;
+        }
+        for(; contor < strlen(text2); contor++) {
+            if(IsUpper(text2[contor]) && !isdigit(text2[contor]))
+                caps++;
+            len++;
+        }
+        /* Added divide by 0 check --alxbl */
+        if(len != 0 && ((caps*100)/(len)) >= 50) {
+            sendto_one_numeric(data->source_p, 404,
+                               "%s :Cannot send to channel - Your message contains mostly capital letters (+G set)",
+                               data->chptr->chname);
+            return;
+        }
+    }
+}
+
+static int
+_modinit(void)
+{
+    mode_nocaps = cflag_add('G', chm_simple);
+    if (mode_nocaps == 0)
+        return -1;
+
+    return 0;
+}
+
+static void
+_moddeinit(void)
+{
+    cflag_orphan('G');
+}
+
+DECLARE_MODULE_AV1(chm_nocaps, _modinit, _moddeinit, NULL, NULL, chm_nocaps_hfnlist, "$Revision$");

--- a/extensions/chm_norepeat.c
+++ b/extensions/chm_norepeat.c
@@ -1,0 +1,93 @@
+/*
+ * Elemental-IRCd
+ * chm_norepeat: blocks repeating messages (+K mode).
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice is present in all copies.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "chmode.h"
+#include "inline/stringops.h"
+
+static unsigned int mode_norepeat;
+
+static void chm_norepeat_process(hook_data_privmsg_channel *);
+
+mapi_hfn_list_av1 chm_norepeat_hfnlist[] = {
+    { "privmsg_channel", (hookfn) chm_norepeat_process },
+    { NULL, NULL }
+};
+
+static void
+chm_norepeat_process(hook_data_privmsg_channel *data)
+{
+    char text2[BUFSIZE];
+    struct Metadata *md;
+    struct membership *msptr = find_channel_membership(data->chptr, data->source_p);
+
+    /* don't waste CPU if message is already blocked */
+    if (data->approved) {
+        return;
+    }
+
+    if(data->chptr->mode.mode & mode_norepeat) {
+        rb_strlcpy(text2, data->text, BUFSIZE);
+        strip_unprintable(text2);
+        md = channel_metadata_find(data->chptr, "NOREPEAT");
+
+        if(md && (!ConfigChannel.exempt_cmode_K || !is_any_op(msptr))) {
+            if(!(strcmp(md->value, text2))) {
+                if(data->msgtype != MESSAGE_TYPE_NOTICE) {
+                    sendto_one_numeric(data->source_p, ERR_CANNOTSENDTOCHAN,
+                                       "%s :Cannot send to channel - Message blocked due to repeating (+K set)",
+                                       data->chptr->chname);
+                    data->approved = ERR_CANNOTSENDTOCHAN;
+                }
+            }
+        }
+
+        channel_metadata_delete(data->chptr, "NOREPEAT", 0);
+        channel_metadata_add(data->chptr, "NOREPEAT", text2, 0);
+    }
+}
+
+static int
+_modinit(void)
+{
+    mode_norepeat = cflag_add('K', chm_simple);
+    if (mode_norepeat == 0)
+        return -1;
+
+    return 0;
+}
+
+static void
+_moddeinit(void)
+{
+    cflag_orphan('K');
+}
+
+DECLARE_MODULE_AV1(chm_norepeat, _modinit, _moddeinit, NULL, NULL, chm_norepeat_hfnlist, "$Revision$");

--- a/help/opers/cmode
+++ b/help/opers/cmode
@@ -19,7 +19,7 @@ NO PARAMETERS:
               join the channel.
      +r     - Registered users only.  Only users identified to services
               may join.
-     +c     - No color.  All color codes in messages are stripped.
+   ? +c     - No color.  All color codes in messages are stripped.
      +d     - No nick changes. People on the channel will not be able to
               change nick.
      +g     - Free invite.  Everyone may invite users.  Significantly
@@ -34,19 +34,17 @@ NO PARAMETERS:
               ops are necessary).
      +Q     - Disable forward.  Users cannot be forwarded to the channel
               (however, new forwards can still be set subject to +F).
-     +C     - Disable CTCP. All CTCP messages to the channel, except ACTION,
+   ? +C     - Disable CTCP. All CTCP messages to the channel, except ACTION,
               are disallowed.
-     +D     - Disable CTCP ACTION. All CTCP ACTIONs to the channel will
-              be blocked.
-     +T     - Disable notice. All notices to the channel are disallowed.
+   ? +T     - Disable notice. All notices to the channel are disallowed.
      +E     - No kicks. Chanops will not be able to use /kick on this
               channel.
-     +G     - Block messages in all caps. Messages that are more than
+   ? +G     - Block messages in all caps. Messages that are more than
               50% capital letters will be blocked. Messages shorter than
               10 characters are ignored.
      +J     - Prevent automatic rejoin on kick. Users will not be able to
               rejoin immediately after being kicked.
-     +K     - No repeat messages. Messages that are the same as the
+   ? +K     - No repeat messages. Messages that are the same as the
               last message sent to the channel will be blocked.
    * +M     - Immune. Opers cannot be kicked from the channel. May
               be set by server admins regardless of channel status.

--- a/help/users/cmode
+++ b/help/users/cmode
@@ -19,7 +19,7 @@ NO PARAMETERS:
               join the channel.
      +r     - Registered users only.  Only users identified to services
               may join.
-     +c     - No color.  All color codes in messages are stripped.
+   ? +c     - No color.  All color codes in messages are stripped.
      +d     - No nickchanges. People on the channel will not be able to
               change nick.
      +g     - Free invite.  Everyone may invite users.  Significantly
@@ -34,14 +34,12 @@ NO PARAMETERS:
               ops are necessary).
      +Q     - Disable forward.  Users cannot be forwarded to the channel
               (however, new forwards can still be set subject to +F).
-     +C     - Disable CTCP. All CTCP messages to the channel, except ACTION,
+   ? +C     - Disable CTCP. All CTCP messages to the channel, except ACTION,
               are disallowed.
-     +D     - Disable CTCP ACTION. All CTCP ACTIONs to the channel will
-              be blocked.
-     +T     - Disable notice. All notices to the channel are disallowed.
+   ? +T     - Disable notice. All notices to the channel are disallowed.
      +E     - No kicks. Chanops will not be able to use /kick on this
               channel.
-     +G     - Block messages in all caps. Messages that are more than
+   ? +G     - Block messages in all caps. Messages that are more than
               50% capital letters will be blocked. Messages shorter than
               10 characters are ignored.
      +J     - Prevent automatic rejoin on kick. Users will not be able to

--- a/include/channel.h
+++ b/include/channel.h
@@ -167,7 +167,6 @@ typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,
 #define MODE_INVITEONLY 0x0010
 #define MODE_NOPRIVMSGS 0x0020
 #define MODE_REGONLY	0x0040
-#define MODE_NOCOLOR	0x0080
 #define MODE_EXLIMIT	0x0100  /* exempt from list limits, +b/+e/+I/+q */
 #define MODE_PERMANENT  0x0200  /* permanant channel, +P */
 #define MODE_OPMODERATE 0x0400  /* send rejected messages to ops */

--- a/include/channel.h
+++ b/include/channel.h
@@ -173,7 +173,6 @@ typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,
 #define MODE_FREEINVITE 0x0800  /* allow free use of /invite */
 #define MODE_FREETARGET 0x1000  /* can be forwarded to without authorization */
 #define MODE_DISFORWARD 0x2000  /* disable channel forwarding */
-#define MODE_NOCTCP     0x8000  /* Block CTCPs directed to this channel */
 #define MODE_NONOTICE	0x10000	/* Block notices directed to this channel */
 #define MODE_NOACTION	0x20000 /* Block CTCP ACTION directed to this channel */
 #define MODE_NOKICK	0x40000 /* Disable /kick on this channel */

--- a/include/channel.h
+++ b/include/channel.h
@@ -179,7 +179,6 @@ typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,
 #define MODE_NONICK	0x80000 /* Disable /nick for anyone on this channel */
 #define MODE_NOCAPS	0x100000 /* Block messages in all capital letters */
 #define MODE_NOREJOIN	0x200000 /* Block rejoin immediately after kick */
-#define MODE_NOREPEAT	0x400000 /* Block repeat messages */
 #define MODE_NOOPERKICK	0x800000 /* disallow kicking opers */
 #define MODE_HIDEBANS	0x1000000 /* disallow non-chanops from seeing ban/quiet lists */
 

--- a/include/channel.h
+++ b/include/channel.h
@@ -177,7 +177,6 @@ typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,
 #define MODE_NOACTION	0x20000 /* Block CTCP ACTION directed to this channel */
 #define MODE_NOKICK	0x40000 /* Disable /kick on this channel */
 #define MODE_NONICK	0x80000 /* Disable /nick for anyone on this channel */
-#define MODE_NOCAPS	0x100000 /* Block messages in all capital letters */
 #define MODE_NOREJOIN	0x200000 /* Block rejoin immediately after kick */
 #define MODE_NOOPERKICK	0x800000 /* disallow kicking opers */
 #define MODE_HIDEBANS	0x1000000 /* disallow non-chanops from seeing ban/quiet lists */

--- a/include/channel.h
+++ b/include/channel.h
@@ -173,7 +173,6 @@ typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,
 #define MODE_FREEINVITE 0x0800  /* allow free use of /invite */
 #define MODE_FREETARGET 0x1000  /* can be forwarded to without authorization */
 #define MODE_DISFORWARD 0x2000  /* disable channel forwarding */
-#define MODE_NONOTICE	0x10000	/* Block notices directed to this channel */
 #define MODE_NOACTION	0x20000 /* Block CTCP ACTION directed to this channel */
 #define MODE_NOKICK	0x40000 /* Disable /kick on this channel */
 #define MODE_NONICK	0x80000 /* Disable /nick for anyone on this channel */

--- a/include/channel.h
+++ b/include/channel.h
@@ -173,7 +173,6 @@ typedef int (*ExtbanFunc)(const char *data, struct Client *client_p,
 #define MODE_FREEINVITE 0x0800  /* allow free use of /invite */
 #define MODE_FREETARGET 0x1000  /* can be forwarded to without authorization */
 #define MODE_DISFORWARD 0x2000  /* disable channel forwarding */
-#define MODE_NOACTION	0x20000 /* Block CTCP ACTION directed to this channel */
 #define MODE_NOKICK	0x40000 /* Disable /kick on this channel */
 #define MODE_NONICK	0x80000 /* Disable /nick for anyone on this channel */
 #define MODE_NOREJOIN	0x200000 /* Block rejoin immediately after kick */

--- a/include/hook.h
+++ b/include/hook.h
@@ -28,6 +28,8 @@ extern int h_new_local_user;
 extern int h_new_remote_user;
 extern int h_introduce_client;
 extern int h_can_kick;
+extern int h_privmsg_channel;
+extern int h_privmsg_user;
 
 void init_hook(void);
 int register_hook(const char *name);
@@ -88,5 +90,29 @@ typedef struct {
     unsigned int oldumodes;
     unsigned int oldsnomask;
 } hook_data_umode_changed;
+
+enum message_type {
+       MESSAGE_TYPE_NOTICE,
+       MESSAGE_TYPE_PRIVMSG,
+       MESSAGE_TYPE_COUNT
+};
+
+typedef struct
+{
+       enum message_type msgtype;
+       struct Client *source_p;
+       struct Channel *chptr;
+       const char *text;
+       int approved;
+} hook_data_privmsg_channel;
+
+typedef struct
+{
+       enum message_type msgtype;
+       struct Client *source_p;
+       struct Client *target_p;
+       const char *text;
+       int approved;
+} hook_data_privmsg_user;
 
 #endif

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -21,7 +21,8 @@ module_DATA =  core/m_ban.so             \
                core/m_squit.so
 
 
-automod_DATA = m_accept.so               \
+automod_DATA = chm_nocolour.so           \
+               m_accept.so               \
                m_admin.so                \
                m_away.so                 \
                m_capab.so                \

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -23,6 +23,7 @@ module_DATA =  core/m_ban.so             \
 
 automod_DATA = chm_nocolour.so           \
                chm_noctcp.so             \
+               chm_nonotice.so           \
                m_accept.so               \
                m_admin.so                \
                m_away.so                 \

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -22,6 +22,7 @@ module_DATA =  core/m_ban.so             \
 
 
 automod_DATA = chm_nocolour.so           \
+               chm_noctcp.so             \
                m_accept.so               \
                m_admin.so                \
                m_away.so                 \

--- a/modules/chm_nocolour.c
+++ b/modules/chm_nocolour.c
@@ -1,0 +1,82 @@
+/*
+ * charybdis: an advanced ircd.
+ * chm_nocolour: strip colours (+c mode).
+ *
+ * Copyright (c) 2012 William Pitcock <nenolod@dereferenced.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice is present in all copies.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "chmode.h"
+#include "inline/stringops.h"
+
+static char buf[BUFSIZE];
+static unsigned int mode_nocolour;
+
+static void chm_nocolour_process(hook_data_privmsg_channel *);
+
+mapi_hfn_list_av1 chm_nocolour_hfnlist[] = {
+    { "privmsg_channel", (hookfn) chm_nocolour_process },
+    { NULL, NULL }
+};
+
+static void
+chm_nocolour_process(hook_data_privmsg_channel *data)
+{
+    /* don't waste CPU if message is already blocked */
+    if (data->approved) {
+        return;
+    }
+
+    struct membership *msptr = find_channel_membership(data->chptr, data->source_p);
+
+    if (data->chptr->mode.mode & mode_nocolour &&
+        (!ConfigChannel.exempt_cmode_c || !is_any_op(msptr))) {
+        rb_strlcpy(buf, data->text, sizeof buf);
+        strip_colour(buf);
+
+        data->text = buf;
+    }
+}
+
+static int
+_modinit(void)
+{
+    mode_nocolour = cflag_add('c', chm_simple);
+    if (mode_nocolour == 0)
+        return -1;
+
+    return 0;
+}
+
+static void
+_moddeinit(void)
+{
+    cflag_orphan('c');
+}
+
+DECLARE_MODULE_AV1(chm_nocolour, _modinit, _moddeinit, NULL, NULL, chm_nocolour_hfnlist, "$Revision$");

--- a/modules/chm_noctcp.c
+++ b/modules/chm_noctcp.c
@@ -1,0 +1,82 @@
+/*
+ * charybdis: an advanced ircd.
+ * chm_noctcp: block non-action CTCP (+C mode).
+ *
+ * Copyright (c) 2012 William Pitcock <nenolod@dereferenced.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice is present in all copies.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "chmode.h"
+#include "inline/stringops.h"
+
+static unsigned int mode_noctcp;
+
+static void chm_noctcp_process(hook_data_privmsg_channel *);
+
+mapi_hfn_list_av1 chm_noctcp_hfnlist[] = {
+    { "privmsg_channel", (hookfn) chm_noctcp_process },
+    { NULL, NULL }
+};
+
+static void
+chm_noctcp_process(hook_data_privmsg_channel *data)
+{
+    /* don't waste CPU if message is already blocked */
+    if (data->approved || data->msgtype == MESSAGE_TYPE_NOTICE)
+        return;
+
+    struct membership *msptr = find_channel_membership(data->chptr, data->source_p);
+
+    if (*data->text == '\001'
+        && strncasecmp(data->text + 1, "ACTION ", 7)
+        && data->chptr->mode.mode & mode_noctcp
+        && (!ConfigChannel.exempt_cmode_C || !is_any_op(msptr))) {
+        sendto_one_numeric(data->source_p, ERR_CANNOTSENDTOCHAN, form_str(ERR_CANNOTSENDTOCHAN), data->chptr->chname);
+        data->approved = ERR_CANNOTSENDTOCHAN;
+        return;
+    } else if (rb_dlink_list_length(&data->chptr->locmembers) > (unsigned)(GlobalSetOptions.floodcount / 2))
+        data->source_p->large_ctcp_sent = rb_current_time();
+}
+
+static int
+_modinit(void)
+{
+    mode_noctcp = cflag_add('C', chm_simple);
+    if (mode_noctcp == 0)
+        return -1;
+
+    return 0;
+}
+
+static void
+_moddeinit(void)
+{
+    cflag_orphan('C');
+}
+
+DECLARE_MODULE_AV1(chm_noctcp, _modinit, _moddeinit, NULL, NULL, chm_noctcp_hfnlist, "$Revision$");

--- a/modules/chm_nonotice.c
+++ b/modules/chm_nonotice.c
@@ -1,0 +1,83 @@
+/*
+ * charybdis: an advanced ircd.
+ * chm_nonotice: block non-action CTCP (+C mode).
+ *
+ * Copyright (c) 2012 William Pitcock <nenolod@dereferenced.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice is present in all copies.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "chmode.h"
+#include "inline/stringops.h"
+
+static unsigned int mode_nonotice;
+
+static void chm_nonotice_process(hook_data_privmsg_channel *);
+
+mapi_hfn_list_av1 chm_nonotice_hfnlist[] = {
+    { "privmsg_channel", (hookfn) chm_nonotice_process },
+    { NULL, NULL }
+};
+
+static void
+chm_nonotice_process(hook_data_privmsg_channel *data)
+{
+    /* don't waste CPU if message is already blocked */
+    if (data->approved || data->msgtype == MESSAGE_TYPE_NOTICE)
+        return;
+
+    struct membership *msptr = find_channel_membership(data->chptr, data->source_p);
+
+    if(data->msgtype == MESSAGE_TYPE_NOTICE) {
+        if(data->chptr->mode.mode & mode_nonotice &&
+           (!ConfigChannel.exempt_cmode_T || !is_any_op(msptr))) {
+            sendto_one_numeric(data->source_p, 404,
+                               "%s :Cannot send to channel - Notices are disallowed (+T set)",
+                               data->chptr->chname);
+
+            data->approved = 404;
+        }
+    }
+}
+
+static int
+_modinit(void)
+{
+    mode_nonotice = cflag_add('T', chm_simple);
+    if (mode_nonotice == 0)
+        return -1;
+
+    return 0;
+}
+
+static void
+_moddeinit(void)
+{
+    cflag_orphan('T');
+}
+
+DECLARE_MODULE_AV1(chm_nonotice, _modinit, _moddeinit, NULL, NULL, chm_nonotice_hfnlist, "$Revision$");

--- a/modules/chm_nonotice.c
+++ b/modules/chm_nonotice.c
@@ -52,8 +52,9 @@ chm_nonotice_process(hook_data_privmsg_channel *data)
 
     struct membership *msptr = find_channel_membership(data->chptr, data->source_p);
 
+    // Also allow CTCP replies here.
     if(data->msgtype == MESSAGE_TYPE_NOTICE) {
-        if(data->chptr->mode.mode & mode_nonotice &&
+        if(data->chptr->mode.mode & mode_nonotice && *data->text != '\001' &&
            (!ConfigChannel.exempt_cmode_T || !is_any_op(msptr))) {
             sendto_one_numeric(data->source_p, 404,
                                "%s :Cannot send to channel - Notices are disallowed (+T set)",

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -459,7 +459,6 @@ msg_channel(enum message_type msgtype,
     int caps = 0;
     int len = 0;
     struct membership *msptr = find_channel_membership(chptr, source_p);
-    struct Metadata *md;
     hook_data_privmsg_channel hdata;
 
     if(MyClient(source_p)) {
@@ -467,21 +466,6 @@ msg_channel(enum message_type msgtype,
         if(msgtype != MESSAGE_TYPE_NOTICE) {
             source_p->localClient->last = rb_current_time();
         }
-    }
-
-    if(chptr->mode.mode & MODE_NOREPEAT) {
-        rb_strlcpy(text2, text, BUFSIZE);
-        strip_unprintable(text2);
-        md = channel_metadata_find(chptr, "NOREPEAT");
-        if(md && (!ConfigChannel.exempt_cmode_K || !is_any_op(msptr))) {
-            if(!(strcmp(md->value, text2))) {
-                if(msgtype != MESSAGE_TYPE_NOTICE)
-                    sendto_one_numeric(source_p, 404, "%s :Cannot send to channel - Message blocked due to repeating (+K set)", chptr->chname);
-                return;
-            }
-        }
-        channel_metadata_delete(chptr, "NOREPEAT", 0);
-        channel_metadata_add(chptr, "NOREPEAT", text2, 0);
     }
 
     // Must be processed before chmode c --SnoFox
@@ -589,7 +573,6 @@ msg_channel_opmod(enum message_type msgtype,
                   struct Client *client_p, struct Client *source_p,
                   struct Channel *chptr, const char *text)
 {
-    char text2[BUFSIZE];
     hook_data_privmsg_channel hdata;
 
     hdata.msgtype = msgtype;

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -546,10 +546,7 @@ msg_channel(enum message_type msgtype,
             }
             if (msgtype != MESSAGE_TYPE_NOTICE && *text == '\001' &&
                 strncasecmp(text + 1, "ACTION ", 7)) {
-                if (chptr->mode.mode & MODE_NOCTCP && (!ConfigChannel.exempt_cmode_C || !is_any_op(msptr))) {
-                    sendto_one_numeric(source_p, 404, "%s :Cannot send to channel - CTCPs to this channel are disallowed (+C set)", chptr->chname);
-                    return;
-                } else if (rb_dlink_list_length(&chptr->locmembers) > (unsigned)(GlobalSetOptions.floodcount / 2))
+                if (rb_dlink_list_length(&chptr->locmembers) > (unsigned)(GlobalSetOptions.floodcount / 2))
                     source_p->large_ctcp_sent = rb_current_time();
             }
             sendto_channel_flags(client_p, ALL_MEMBERS, source_p, chptr,
@@ -798,13 +795,8 @@ msg_client(enum message_type msgtype,
             return;
         }
 
-        if (IsSetNoCTCP(target_p) && (msgtype != MESSAGE_TYPE_NOTICE) && *text == '\001' && strncasecmp(text + 1, "ACTION", 6)) {
-            sendto_one_numeric(source_p, ERR_NOCTCP,
-                               form_str(ERR_NOCTCP),
-                               target_p->name);
-        }
         /* If opers want to go through +g, they should load oaccept.*/
-        else if(!IsServer(source_p) && !IsService(source_p) && (IsSetCallerId(target_p) ||
+        if(!IsServer(source_p) && !IsService(source_p) && (IsSetCallerId(target_p) ||
                 (IsSetSCallerId(target_p) && !has_common_channel(source_p, target_p)) ||
                 (IsSetRegOnlyMsg(target_p) && !source_p->user->suser[0]))) {
             if (IsOper(source_p)) {

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -508,19 +508,6 @@ msg_channel(enum message_type msgtype,
         }
     }
 
-    if(chptr->mode.mode & MODE_NOCOLOR && (!ConfigChannel.exempt_cmode_c || !is_any_op(msptr))) {
-        rb_strlcpy(text2, text, BUFSIZE);
-        strip_colour(text2);
-        text = text2;
-        if (EmptyString(text)) {
-            /* could be empty after colour stripping and
-             * that would cause problems later */
-            if(msgtype != MESSAGE_TYPE_NOTICE)
-                sendto_one(source_p, form_str(ERR_NOTEXTTOSEND), me.name, source_p->name);
-            return;
-        }
-    }
-
     hdata.msgtype = msgtype;
     hdata.source_p = source_p;
     hdata.chptr = chptr;
@@ -607,19 +594,6 @@ msg_channel_opmod(enum message_type msgtype,
 {
     char text2[BUFSIZE];
     hook_data_privmsg_channel hdata;
-
-    if(chptr->mode.mode & MODE_NOCOLOR) {
-        rb_strlcpy(text2, text, BUFSIZE);
-        strip_colour(text2);
-        text = text2;
-        if (EmptyString(text)) {
-            /* could be empty after colour stripping and
-             * that would cause problems later */
-            if(msgtype != MESSAGE_TYPE_NOTICE)
-                sendto_one(source_p, form_str(ERR_NOTEXTTOSEND), me.name, source_p->name);
-            return;
-        }
-    }
 
     hdata.msgtype = msgtype;
     hdata.source_p = source_p;

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -490,17 +490,6 @@ msg_channel(enum message_type msgtype,
         }
         if(result == CAN_SEND_OPV ||
            !flood_attack_channel(msgtype, source_p, chptr, chptr->chname)) {
-            if (msgtype != MESSAGE_TYPE_NOTICE && chptr->mode.mode & MODE_NOACTION &&
-                !strncasecmp(text + 1, "ACTION", 6) &&
-                (!ConfigChannel.exempt_cmode_D || !is_any_op(msptr))) {
-                sendto_one_numeric(source_p, 404, "%s :Cannot send to channel - ACTIONs are disallowed (+D set)", chptr->chname);
-                return;
-            }
-            if (msgtype != MESSAGE_TYPE_NOTICE && *text == '\001' &&
-                strncasecmp(text + 1, "ACTION ", 7)) {
-                if (rb_dlink_list_length(&chptr->locmembers) > (unsigned)(GlobalSetOptions.floodcount / 2))
-                    source_p->large_ctcp_sent = rb_current_time();
-            }
             sendto_channel_flags(client_p, ALL_MEMBERS, source_p, chptr,
                                  "%s %s :%s", cmdname[msgtype], chptr->chname, text);
         }

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -454,10 +454,6 @@ msg_channel(enum message_type msgtype,
             const char *text)
 {
     int result;
-    char text2[BUFSIZE];
-    size_t contor;
-    int caps = 0;
-    int len = 0;
     struct membership *msptr = find_channel_membership(chptr, source_p);
     hook_data_privmsg_channel hdata;
 
@@ -465,30 +461,6 @@ msg_channel(enum message_type msgtype,
         /* idle time shouldnt be reset by notices --fl */
         if(msgtype != MESSAGE_TYPE_NOTICE) {
             source_p->localClient->last = rb_current_time();
-        }
-    }
-
-    // Must be processed before chmode c --SnoFox
-    if (strlen(text) > 10 && chptr->mode.mode & MODE_NOCAPS && (!ConfigChannel.exempt_cmode_G || !is_any_op(msptr))) {
-        rb_strlcpy(text2, text, BUFSIZE);
-        strip_unprintable(text2);
-
-        // Don't count the "ACTION" part of action as part of the message --SnoFox
-        if (msgtype != MESSAGE_TYPE_NOTICE && *text == '\001' &&
-            !strncasecmp(text + 1, "ACTION ", 7)) {
-            contor = 7;
-        } else {
-            contor = 0;
-        }
-        for(; contor < strlen(text2); contor++) {
-            if(IsUpper(text2[contor]) && !isdigit(text2[contor]))
-                caps++;
-            len++;
-        }
-        /* Added divide by 0 check --alxbl */
-        if(len != 0 && ((caps*100)/(len)) >= 50) {
-            sendto_one_numeric(source_p, 404, "%s :Cannot send to channel - Your message contains mostly capital letters (+G set)", chptr->chname);
-            return;
         }
     }
 

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -319,9 +319,15 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
         /*  allow %+@ if someone wants to do that */
         for(;;) {
             if(*nick == '@')
-                type |= CHFL_CHANOP;
+                type |= CHFL_CHANOP | CHFL_ADMIN | CHFL_OWNER;
             else if(*nick == '+')
-                type |= CHFL_CHANOP | CHFL_VOICE;
+                type |= CHFL_CHANOP | CHFL_VOICE | CHFL_HALFOP | CHFL_ADMIN | CHFL_OWNER;
+            else if(*nick == '%')
+                type |= CHFL_CHANOP | CHFL_HALFOP | CHFL_ADMIN | CHFL_OWNER;
+            else if(*nick == '!')
+                type |= CHFL_ADMIN | CHFL_OWNER;
+            else if(*nick == '~')
+                type = CHFL_OWNER;
             else
                 break;
             nick++;

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -490,10 +490,6 @@ msg_channel(enum message_type msgtype,
         }
         if(result == CAN_SEND_OPV ||
            !flood_attack_channel(msgtype, source_p, chptr, chptr->chname)) {
-            if (msgtype != MESSAGE_TYPE_NOTICE && chptr->mode.mode & MODE_NONOTICE && (!ConfigChannel.exempt_cmode_T || !is_any_op(msptr))) {
-                sendto_one_numeric(source_p, 404, "%s :Cannot send to channel - Notices are disallowed (+T set)", chptr->chname);
-                return;
-            }
             if (msgtype != MESSAGE_TYPE_NOTICE && chptr->mode.mode & MODE_NOACTION &&
                 !strncasecmp(text + 1, "ACTION", 6) &&
                 (!ConfigChannel.exempt_cmode_D || !is_any_op(msptr))) {

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -460,7 +460,6 @@ msg_channel(enum message_type msgtype,
             const char *text)
 {
     int result;
-    struct membership *msptr = find_channel_membership(chptr, source_p);
     hook_data_privmsg_channel hdata;
 
     if(MyClient(source_p)) {

--- a/modules/core/m_part.c
+++ b/modules/core/m_part.c
@@ -123,11 +123,6 @@ part_one_client(struct Client *client_p, struct Client *source_p, char *name, ch
                      ((can_send(chptr, source_p, msptr) > 0 && ConfigFileEntry.use_part_messages &&
                        (source_p->localClient->firsttime +
                         ConfigFileEntry.anti_spam_exit_message_time) < rb_current_time())))) {
-        if(chptr->mode.mode & MODE_NOCOLOR && (!ConfigChannel.exempt_cmode_c || !is_any_op(msptr))) {
-            rb_strlcpy(reason2, reason, BUFSIZE);
-            strip_colour(reason2);
-            reason = reason2;
-        }
         sendto_server(client_p, chptr, CAP_TS6, NOCAPS,
                       ":%s PART %s :%s", use_id(source_p), chptr->chname, reason);
         sendto_channel_local(ALL_MEMBERS, chptr, ":%s!%s@%s PART %s :\"%s\"",

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -1854,7 +1854,7 @@ struct ChannelMode chmode_table[256] = {
 
     {chm_admin,    0 },                   /* a */
     {chm_ban,      CHFL_BAN },            /* b */
-    {chm_simple,   MODE_NOCOLOR },        /* c */
+    {chm_nosuch,   0 },                   /* c */
     {chm_simple,   MODE_NONICK },         /* d */
     {chm_ban,      CHFL_EXCEPTION },      /* e */
     {chm_forward,  0 },                   /* f */

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -1828,7 +1828,7 @@ struct ChannelMode chmode_table[256] = {
     {chm_nosuch,   0 },                   /* H */
     {chm_ban,      CHFL_INVEX },          /* I */
     {chm_simple,   MODE_NOREJOIN },       /* J */
-    {chm_simple,   MODE_NOREPEAT },       /* K */
+    {chm_nosuch,   0 },                   /* K */
     {chm_staff,    MODE_EXLIMIT },        /* L */
     {chm_hidden,   MODE_NOOPERKICK },     /* M */
     {chm_nosuch,   0 },                   /* N */

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -1820,7 +1820,7 @@ struct ChannelMode chmode_table[256] = {
     {chm_nosuch,   0 },                   /* @ */
     {chm_nosuch,   0 },                   /* A */
     {chm_nosuch,   0 },                   /* B */
-    {chm_simple,   MODE_NOCTCP },         /* C */
+    {chm_nosuch,   0 },                   /* C */
     {chm_simple,   MODE_NOACTION },       /* D */
     {chm_simple,   MODE_NOKICK },         /* E */
     {chm_simple,   MODE_FREETARGET },     /* F */

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -1824,7 +1824,7 @@ struct ChannelMode chmode_table[256] = {
     {chm_simple,   MODE_NOACTION },       /* D */
     {chm_simple,   MODE_NOKICK },         /* E */
     {chm_simple,   MODE_FREETARGET },     /* F */
-    {chm_simple,   MODE_NOCAPS },         /* G */
+    {chm_nosuch,   0 },                   /* G */
     {chm_nosuch,   0 },                   /* H */
     {chm_ban,      CHFL_INVEX },          /* I */
     {chm_simple,   MODE_NOREJOIN },       /* J */

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -1837,7 +1837,7 @@ struct ChannelMode chmode_table[256] = {
     {chm_simple,   MODE_DISFORWARD },     /* Q */
     {chm_nosuch,   0 },                   /* R */
     {chm_nosuch,   0 },                   /* S */
-    {chm_simple,   MODE_NONOTICE },       /* T */
+    {chm_nosuch,   0 },                   /* T */
     {chm_nosuch,   0 },                   /* U */
     {chm_nosuch,   0 },                   /* V */
     {chm_nosuch,   0 },                   /* W */

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -141,14 +141,14 @@ construct_cflag_param_string(void)
 
     *cflagsparaminfo = '\0';
     snprintf(cflagsparaminfo, sizeof cflagsparaminfo, "%s%sb%s%s%s%sklov%s%s",
-                ConfigChannel.use_owner ? "y" : "",
-                ConfigChannel.use_admin ? "a" : "",
-                ConfigChannel.use_except ? "e" : "",
-                ConfigChannel.use_forward ? "f" : "",
-                ConfigChannel.use_halfop ? "h" : "",
-                strchr(ConfigChannel.disabledmodes, 'j') ? "" : "j",
-                strchr(ConfigChannel.disabledmodes, 'q') ? "" : "q",
-                ConfigChannel.use_invex ? "I" : "");
+             ConfigChannel.use_owner ? "y" : "",
+             ConfigChannel.use_admin ? "a" : "",
+             ConfigChannel.use_except ? "e" : "",
+             ConfigChannel.use_forward ? "f" : "",
+             ConfigChannel.use_halfop ? "h" : "",
+             strchr(ConfigChannel.disabledmodes, 'j') ? "" : "j",
+             strchr(ConfigChannel.disabledmodes, 'q') ? "" : "q",
+             ConfigChannel.use_invex ? "I" : "");
 }
 
 /*
@@ -1821,7 +1821,7 @@ struct ChannelMode chmode_table[256] = {
     {chm_nosuch,   0 },                   /* A */
     {chm_nosuch,   0 },                   /* B */
     {chm_nosuch,   0 },                   /* C */
-    {chm_simple,   MODE_NOACTION },       /* D */
+    {chm_nosuch,   0 },                   /* D */
     {chm_simple,   MODE_NOKICK },         /* E */
     {chm_simple,   MODE_FREETARGET },     /* F */
     {chm_nosuch,   0 },                   /* G */
@@ -2099,8 +2099,8 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
         sprintf(cmdbuf, ":%s MODE %s ", fakesource_p->name, chptr->chname);
     else
         sprintf(cmdbuf, ":%s!%s@%s MODE %s ",
-                   source_p->name, source_p->username,
-                   source_p->host, chptr->chname);
+                source_p->name, source_p->username,
+                source_p->host, chptr->chname);
 
     mlen = 0;
 

--- a/src/hook.c
+++ b/src/hook.c
@@ -63,6 +63,8 @@ int h_new_local_user;
 int h_new_remote_user;
 int h_introduce_client;
 int h_can_kick;
+int h_privmsg_user;
+int h_privmsg_channel;
 
 void
 init_hook(void)
@@ -86,6 +88,8 @@ init_hook(void)
     h_new_remote_user = register_hook("new_remote_user");
     h_introduce_client = register_hook("introduce_client");
     h_can_kick = register_hook("can_kick");
+    h_privmsg_user = register_hook("privmsg_user");
+    h_privmsg_channel = register_hook("privmsg_channel");
 }
 
 /* grow_hooktable()

--- a/src/supported.c
+++ b/src/supported.c
@@ -220,12 +220,12 @@ isupport_chanmodes(const void *ptr)
     static char result[80];
 
     snprintf(result, sizeof result, "%s%sb%s,k,%sl%s,%s",
-                ConfigChannel.use_except ? "e" : "",
-                ConfigChannel.use_invex ? "I" : "",
-                strchr(ConfigChannel.disabledmodes, 'q') ? "" : "q",
-                ConfigChannel.use_forward ? "f" : "",
-                strchr(ConfigChannel.disabledmodes, 'j') ? "" : "j",
-                cflagsbuf);
+             ConfigChannel.use_except ? "e" : "",
+             ConfigChannel.use_invex ? "I" : "",
+             strchr(ConfigChannel.disabledmodes, 'q') ? "" : "q",
+             ConfigChannel.use_forward ? "f" : "",
+             strchr(ConfigChannel.disabledmodes, 'j') ? "" : "j",
+             cflagsbuf);
     return result;
 }
 
@@ -241,8 +241,8 @@ isupport_chanlimit(const void *ptr)
     static char result[30];
 
     snprintf(result, sizeof result, "%s:%i",
-                ConfigChannel.use_local_channels ? "&#" : "#",
-                ConfigChannel.max_chans_per_user);
+             ConfigChannel.use_local_channels ? "&#" : "#",
+             ConfigChannel.max_chans_per_user);
     return result;
 }
 
@@ -252,12 +252,12 @@ isupport_prefix(const void *ptr)
     static char result[13];
 
     snprintf(result, sizeof result, "(%s%so%sv)%s%s@%s+",
-                ConfigChannel.use_owner ? "y" : "",
-                ConfigChannel.use_admin ? "a" : "",
-                ConfigChannel.use_halfop ? "h" : "",
-                ConfigChannel.use_owner ? "~" : "",
-                ConfigChannel.use_admin ? "!" : "",
-                ConfigChannel.use_halfop ? "%" : "");
+             ConfigChannel.use_owner ? "y" : "",
+             ConfigChannel.use_admin ? "a" : "",
+             ConfigChannel.use_halfop ? "h" : "",
+             ConfigChannel.use_owner ? "~" : "",
+             ConfigChannel.use_admin ? "!" : "",
+             ConfigChannel.use_halfop ? "%" : "");
     return result;
 }
 
@@ -267,9 +267,9 @@ isupport_maxlist(const void *ptr)
     static char result[30];
 
     snprintf(result, sizeof result, "bq%s%s:%i",
-                ConfigChannel.use_except ? "e" : "",
-                ConfigChannel.use_invex ? "I" : "",
-                ConfigChannel.max_bans);
+             ConfigChannel.use_except ? "e" : "",
+             ConfigChannel.use_invex ? "I" : "",
+             ConfigChannel.max_bans);
     return result;
 }
 
@@ -279,8 +279,8 @@ isupport_targmax(const void *ptr)
     static char result[200];
 
     snprintf(result, sizeof result, "NAMES:1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:%d,NOTICE:%d,ACCEPT:,MONITOR:",
-                ConfigFileEntry.max_targets,
-                ConfigFileEntry.max_targets);
+             ConfigFileEntry.max_targets,
+             ConfigFileEntry.max_targets);
     return result;
 }
 
@@ -329,7 +329,7 @@ init_isupport(void)
     add_isupport("MODES", isupport_intptr, &maxmodes);
     add_isupport("NETWORK", isupport_stringptr, &ServerInfo.network_name);
     add_isupport("KNOCK", isupport_boolean, &ConfigChannel.use_knock);
-    add_isupport("STATUSMSG", isupport_string, "@+");
+    add_isupport("STATUSMSG", isupport_string, "~!@%+");
     add_isupport("CALLERID", isupport_string, "g");
     add_isupport("CASEMAPPING", isupport_string, "rfc1459");
     add_isupport("NICKLEN", isupport_intptr, &nicklen);


### PR DESCRIPTION
> This will allow us to modularize message processing, e.g. having new
> modules to manipulate channel and private messages in new ways.
>
> Yes: it can be used to intercept messages, but such modules are already
> out in the wild for charybdis anyway -- so this doesn't really change
> anything there.
>
> If you are changing the text, then it is your responsibility to provide
> a pointer to a new buffer.  This buffer should be statically allocated
> and stored in your module's BSS segment.
>
> We will not, and cannot, free your buffer in core, so dynamically
> allocated buffers will cause a memory leak.
>
> This will allow us to simplify m_message considerably, by moving channel
> mode logic out to their own modules.