### PR TITLE
Revert "Set FD_CLOEXEC if available"

### DIFF
--- a/libratbox/src/commio.c
+++ b/libratbox/src/commio.c
@@ -789,10 +789,6 @@ rb_open(int fd, uint8_t type, const char *desc)
 
     F = add_fd(fd);
 
-#ifdef FD_CLOEXEC
-    fcntl(fd, F_SETFD, FD_CLOEXEC);
-#endif
-
     lrb_assert(!IsFDOpen(F));
     if(rb_unlikely(IsFDOpen(F))) {
         const char *fdesc;


### PR DESCRIPTION
This reverts commit dd81978712a73d4b3226347d136b1180674496f0.

This is a security patch, but it breaks how part of elemental works with helper processes. This can be reapplied when the proper child process stuff is implemented.

Closes #96