### PR TITLE
FD Inheritence fix/cleanup and the beginings of a test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ script:
   - ./autogen.sh
   - ./configure --enable-assert
   - make
+  - make install
+  - testsuite/runtest.sh
 
 addons:
   apt:

--- a/bandb/bandb.c
+++ b/bandb/bandb.c
@@ -319,7 +319,7 @@ check_schema(void)
 
         if(!table.row_count)
             rsdb_exec(NULL,
-                      "CREATE TABLE %s (mask1 TEXT, mask2 TEXT, oper TEXT, time INTEGER, perm INTEGER, reason TEXT)",
+                      "CREATE TABLE IF NOT EXISTS %s (mask1 TEXT, mask2 TEXT, oper TEXT, time INTEGER, perm INTEGER, reason TEXT)",
                       bandb_table[i]);
     }
 }

--- a/bandb/bandb.c
+++ b/bandb/bandb.c
@@ -310,6 +310,8 @@ check_schema(void)
     struct rsdb_table table;
     int i;
 
+    rsdb_exec(NULL, "PRAGMA auto_vacuum=FULL");
+
     for(i = 0; i < LAST_BANDB_TYPE; i++) {
         rsdb_exec_fetch(&table,
                         "SELECT name FROM sqlite_master WHERE type='table' AND name='%s'",

--- a/libratbox/include/ratbox_lib.h
+++ b/libratbox/include/ratbox_lib.h
@@ -153,7 +153,7 @@ void rb_lib_restart(const char *, ...) __noreturn;
 void rb_lib_die(const char *, ...) __noreturn;
 void rb_set_time(void);
 
-void rb_lib_init(log_cb * xilog, __noreturn restart_cb * irestart, __noreturn die_cb * idie, int closeall, int maxfds,
+void rb_lib_init(log_cb * xilog, __noreturn restart_cb * irestart, __noreturn die_cb * idie, int maxfds,
                  size_t dh_size, size_t fd_heap_size);
 void rb_lib_loop(long delay);
 

--- a/libratbox/include/rb_commio.h
+++ b/libratbox/include/rb_commio.h
@@ -83,7 +83,7 @@ struct rb_iovec {
 };
 
 
-void rb_fdlist_init(int closeall, int maxfds, size_t heapsize);
+void rb_fdlist_init(int maxfds, size_t heapsize);
 
 rb_fde_t __must_check *rb_open(int, uint8_t, const char *);
 void rb_close(rb_fde_t *);

--- a/libratbox/include/rb_commio.h
+++ b/libratbox/include/rb_commio.h
@@ -101,6 +101,7 @@ void rb_note(rb_fde_t *, const char *);
 
 int rb_set_nb(rb_fde_t *);
 int rb_set_buffers(rb_fde_t *, int);
+int rb_set_inherit(rb_fde_t *, int);
 
 int rb_get_sockerr(rb_fde_t *);
 

--- a/libratbox/src/commio.c
+++ b/libratbox/src/commio.c
@@ -133,22 +133,6 @@ rb_fd_hack(int *fd)
 #endif
 
 
-/* close_all_connections() can be used *before* the system come up! */
-
-static void
-rb_close_all(void)
-{
-#ifndef _WIN32
-    int i;
-
-    /* XXX someone tell me why we care about 4 fd's ? */
-    /* XXX btw, fd 3 is used for profiler ! */
-    for(i = 3; i < rb_maxconnections; ++i) {
-        close(i);
-    }
-#endif
-}
-
 /*
  * get_sockerr - get the error value from the socket or the current errno
  *
@@ -751,7 +735,7 @@ rb_listen(rb_fde_t *F, int backlog, int defer_accept)
 }
 
 void
-rb_fdlist_init(int closeall, int maxfds, size_t heapsize)
+rb_fdlist_init(int maxfds, size_t heapsize)
 {
     static int initialized = 0;
 #ifdef _WIN32
@@ -767,8 +751,6 @@ rb_fdlist_init(int closeall, int maxfds, size_t heapsize)
 #endif
     if(!initialized) {
         rb_maxconnections = maxfds;
-        if(closeall)
-            rb_close_all();
         /* Since we're doing this once .. */
         initialized = 1;
     }

--- a/libratbox/src/commio.c
+++ b/libratbox/src/commio.c
@@ -110,29 +110,6 @@ free_fds(void)
     }
 }
 
-/* 32bit solaris is kinda slow and stdio only supports fds < 256
- * so we got to do this crap below.
- * (BTW Fuck you Sun, I hate your guts and I hope you go bankrupt soon)
- */
-
-#if defined (__SVR4) && defined (__sun)
-static void
-rb_fd_hack(int *fd)
-{
-    int newfd;
-    if(*fd > 256 || *fd < 0)
-        return;
-    if((newfd = fcntl(*fd, F_DUPFD, 256)) != -1) {
-        close(*fd);
-        *fd = newfd;
-    }
-    return;
-}
-#else
-#define rb_fd_hack(fd)
-#endif
-
-
 /*
  * get_sockerr - get the error value from the socket or the current errno
  *
@@ -317,8 +294,6 @@ rb_accept_tryaccept(rb_fde_t *F, void *data)
             rb_setselect(F, RB_SELECT_ACCEPT, rb_accept_tryaccept, NULL);
             return;
         }
-
-        rb_fd_hack(&new_fd);
 
         new_F = rb_open(new_fd, RB_FD_SOCKET, "Incoming Connection");
 
@@ -541,9 +516,6 @@ rb_socketpair(int family, int sock_type, int proto, rb_fde_t **F1, rb_fde_t **F2
 #endif
         return -1;
 
-    rb_fd_hack(&nfd[0]);
-    rb_fd_hack(&nfd[1]);
-
     *F1 = rb_open(nfd[0], RB_FD_SOCKET, note);
     *F2 = rb_open(nfd[1], RB_FD_SOCKET, note);
 
@@ -588,8 +560,6 @@ rb_pipe(rb_fde_t **F1, rb_fde_t **F2, const char *desc)
     }
     if(pipe(fd) == -1)
         return -1;
-    rb_fd_hack(&fd[0]);
-    rb_fd_hack(&fd[1]);
     *F1 = rb_open(fd[0], RB_FD_PIPE, desc);
     *F2 = rb_open(fd[1], RB_FD_PIPE, desc);
 
@@ -641,7 +611,6 @@ rb_socket(int family, int sock_type, int proto, const char *note)
      * XXX !!! -- adrian
      */
     fd = socket(family, sock_type, proto);
-    rb_fd_hack(&fd);
     if(rb_unlikely(fd < 0))
         return NULL;	/* errno will be passed through, yay.. */
 

--- a/libratbox/src/commio.c
+++ b/libratbox/src/commio.c
@@ -86,6 +86,7 @@ add_fd(int fd)
     F = rb_bh_alloc(fd_heap);
     F->fd = fd;
     rb_dlinkAdd(F, &F->node, &rb_fd_table[rb_hash_fd(fd)]);
+    rb_set_inherit(F, FALSE);
     return (F);
 }
 

--- a/libratbox/src/export-syms.txt
+++ b/libratbox/src/export-syms.txt
@@ -44,6 +44,7 @@ rb_send_fd_buf
 rb_set_buffers
 rb_set_nb
 rb_set_type
+rb_set_inherit
 rb_setselect
 rb_settimeout
 rb_setup_fd

--- a/libratbox/src/helper.c
+++ b/libratbox/src/helper.c
@@ -79,7 +79,7 @@ rb_helper_child(rb_helper_cb * read_cb, rb_helper_cb * error_cb, log_cb * ilog,
     x = 0;			/* shut gcc up */
 #endif
 
-    rb_lib_init(ilog, irestart, idie, 0, maxfd, dh_size, fd_heap_size);
+    rb_lib_init(ilog, irestart, idie, maxfd, dh_size, fd_heap_size);
     rb_linebuf_init(lb_heap_size);
     rb_linebuf_newbuf(&helper->sendq);
     rb_linebuf_newbuf(&helper->recvq);

--- a/libratbox/src/helper.c
+++ b/libratbox/src/helper.c
@@ -45,7 +45,7 @@ rb_helper_child(rb_helper_cb * read_cb, rb_helper_cb * error_cb, log_cb * ilog,
                 size_t fd_heap_size)
 {
     rb_helper *helper;
-    int maxfd, x = 0;
+    int maxfd;
     int ifd, ofd;
     char *tifd, *tofd, *tmaxfd;
 
@@ -60,24 +60,6 @@ rb_helper_child(rb_helper_cb * read_cb, rb_helper_cb * error_cb, log_cb * ilog,
     ifd = (int)strtol(tifd, NULL, 10);
     ofd = (int)strtol(tofd, NULL, 10);
     maxfd = (int)strtol(tmaxfd, NULL, 10);
-
-#ifndef _WIN32
-    for(x = 0; x < maxfd; x++) {
-        if(x != ifd && x != ofd)
-            close(x);
-    }
-    x = open("/dev/null", O_RDWR);
-    if(ifd != 0 && ofd != 0)
-        dup2(x, 0);
-    if(ifd != 1 && ofd != 1)
-        dup2(x, 1);
-    if(ifd != 2 && ofd != 2)
-        dup2(x, 2);
-    if(x > 2)		/* don't undo what we just did */
-        close(x);
-#else
-    x = 0;			/* shut gcc up */
-#endif
 
     rb_lib_init(ilog, irestart, idie, maxfd, dh_size, fd_heap_size);
     rb_linebuf_init(lb_heap_size);

--- a/libratbox/src/helper.c
+++ b/libratbox/src/helper.c
@@ -144,10 +144,8 @@ rb_helper_start(const char *name, const char *fullpath, rb_helper_cb * read_cb,
     parv[0] = buf;
     parv[1] = NULL;
 
-#ifdef _WIN32
-    SetHandleInformation((HANDLE) rb_get_fd(in_f[1]), HANDLE_FLAG_INHERIT, 1);
-    SetHandleInformation((HANDLE) rb_get_fd(out_f[0]), HANDLE_FLAG_INHERIT, 1);
-#endif
+    rb_set_inherit(in_f[1], TRUE);
+    rb_set_inherit(out_f[0], TRUE);
 
     pid = rb_spawn_process(fullpath, (const char **)parv);
 

--- a/libratbox/src/netio/win32.c
+++ b/libratbox/src/netio/win32.c
@@ -177,7 +177,6 @@ rb_setup_fd_win32(rb_fde_t *F)
     if(F == NULL)
         return 0;
 
-    SetHandleInformation((HANDLE) F->fd, HANDLE_FLAG_INHERIT, 0);
     switch (F->type) {
     case RB_FD_SOCKET: {
         u_long nonb = 1;

--- a/libratbox/src/platform/unix.c
+++ b/libratbox/src/platform/unix.c
@@ -151,6 +151,8 @@ static int
 set_fd_flag(int fd, int flag)
 {
     int flags = fcntl(fd, F_GETFD);
+    if(flags & flag) /* Flag already set */
+        return;
     return fcntl(fd, F_SETFD, flags | flag);
 }
 
@@ -158,6 +160,8 @@ static int
 unset_fd_flag(int fd, int flag)
 {
     int flags = fcntl(fd, F_GETFD);
+    if(!(flags & flag)) /* Flag already unset */
+        return;
     return fcntl(fd, F_SETFD, flags & ~flag);
 }
 

--- a/libratbox/src/platform/unix.c
+++ b/libratbox/src/platform/unix.c
@@ -24,7 +24,7 @@
  */
 #include <libratbox_config.h>
 #include <ratbox_lib.h>
-
+#include <commio-int.h>
 
 #ifndef _WIN32
 
@@ -147,5 +147,27 @@ rb_getpid(void)
     return getpid();
 }
 
+static int
+set_fd_flag(int fd, int flag)
+{
+    int flags = fcntl(fd, F_GETFD);
+    return fcntl(fd, F_SETFD, flags | flag);
+}
+
+static int
+unset_fd_flag(int fd, int flag)
+{
+    int flags = fcntl(fd, F_GETFD);
+    return fcntl(fd, F_SETFD, flags & ~flag);
+}
+
+int
+rb_set_inherit(rb_fde_t *F, int inherit)
+{
+    if(inherit)
+        return unset_fd_flag(F->fd, FD_CLOEXEC);
+    else
+        return set_fd_flag(F->fd, FD_CLOEXEC);
+}
 
 #endif /* !WIN32 */

--- a/libratbox/src/platform/windows.c
+++ b/libratbox/src/platform/windows.c
@@ -411,4 +411,11 @@ rb_strerror(int error)
     rb_strlcpy(buf, _rb_strerror(error), sizeof(buf));
     return buf;
 }
+
+int
+rb_set_inherit(rb_fde_t *F, int inherit)
+{
+    return SetHandleInformation((HANDLE) F->fd, HANDLE_FLAG_INHERIT, !!inherit);
+}
+
 #endif /* _WIN32 */

--- a/libratbox/src/ratbox_lib.c
+++ b/libratbox/src/ratbox_lib.c
@@ -177,7 +177,7 @@ rb_set_time(void)
 }
 
 void
-rb_lib_init(log_cb * ilog, __noreturn restart_cb * irestart, __noreturn die_cb * idie, int closeall, int maxcon,
+rb_lib_init(log_cb * ilog, __noreturn restart_cb * irestart, __noreturn die_cb * idie, int maxcon,
             size_t dh_size, size_t fd_heap_size)
 {
     rb_set_time();
@@ -186,7 +186,7 @@ rb_lib_init(log_cb * ilog, __noreturn restart_cb * irestart, __noreturn die_cb *
     rb_die = idie;
     rb_event_init();
     rb_init_bh();
-    rb_fdlist_init(closeall, maxcon, fd_heap_size);
+    rb_fdlist_init(maxcon, fd_heap_size);
     rb_init_netio();
     rb_init_rb_dlink_nodes(dh_size);
     if(rb_io_supports_event()) {

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -609,7 +609,7 @@ main(int argc, char *argv[])
     }
 
     /* Init the event subsystem */
-    rb_lib_init(ircd_log_cb, ircd_restart_cb, ircd_die_cb, !server_state_foreground, maxconnections, DNODE_HEAP_SIZE, FD_HEAP_SIZE);
+    rb_lib_init(ircd_log_cb, ircd_restart_cb, ircd_die_cb, maxconnections, DNODE_HEAP_SIZE, FD_HEAP_SIZE);
     rb_linebuf_init(LINEBUF_HEAP_SIZE);
 
     if(ConfigFileEntry.use_egd && (ConfigFileEntry.egdpool_path != NULL)) {

--- a/src/logger.c
+++ b/src/logger.c
@@ -168,8 +168,8 @@ ilog(ilogfile dest, const char *format, ...)
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
 
-    snprintf(buf2, sizeof(buf2), "%s %s\n",
-                smalldate(rb_current_time()), buf);
+    snprintf(buf2, sizeof(buf2), "%s [%d] %s\n",
+                smalldate(rb_current_time()), rb_getpid(), buf);
 
     if(fputs(buf2, logfile) < 0) {
         fclose(logfile);

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -73,7 +73,7 @@ rb_dlink_list service_list;
 /* internally defined functions */
 static void set_default_conf(void);
 static void validate_conf(void);
-static void read_conf(FILE *);
+static void read_conf(void);
 static void clear_out_old_conf(void);
 
 static void expire_prop_bans(void *list);
@@ -811,12 +811,14 @@ set_default_conf(void)
  * side effects	- Read configuration file.
  */
 static void
-read_conf(FILE * file)
+read_conf(void)
 {
     lineno = 0;
 
     set_default_conf();	/* Set default values prior to conf parsing */
     yyparse();		/* Load the values from the conf */
+    fclose(conf_fbfile_in);
+
     validate_conf();	/* Check to make sure some values are still okay. */
     /* Some global values are also loaded here. */
     check_class();		/* Make sure classes are valid */
@@ -1449,8 +1451,7 @@ read_conf_files(int cold)
         clear_out_old_conf();
     }
 
-    read_conf(conf_fbfile_in);
-    fclose(conf_fbfile_in);
+    read_conf();
 }
 
 /*

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -289,10 +289,9 @@ start_ssldaemon(int count, const char *ssl_cert, const char *ssl_private_key, co
         rb_setenv("CTL_PIPE", fdarg, 1);
         snprintf(s_pid, sizeof(s_pid), "%d", (int)getpid());
         rb_setenv("CTL_PPID", s_pid, 1);
-#ifdef _WIN32
-        SetHandleInformation((HANDLE) rb_get_fd(F2), HANDLE_FLAG_INHERIT, 1);
-        SetHandleInformation((HANDLE) rb_get_fd(P1), HANDLE_FLAG_INHERIT, 1);
-#endif
+
+        rb_set_inherit(F2, TRUE);
+        rb_set_inherit(P1, TRUE);
 
         pid = rb_spawn_process(ssld_path, (const char **) parv);
         if(pid == -1) {

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -1081,7 +1081,7 @@ int
 main(int argc, char **argv)
 {
     const char *s_ctlfd, *s_pipe, *s_pid;
-    int ctlfd, pipefd, x, maxfd;
+    int ctlfd, pipefd, maxfd;
     maxfd = maxconn();
 
     s_ctlfd = getenv("CTL_FD");
@@ -1100,25 +1100,6 @@ main(int argc, char **argv)
     ctlfd = atoi(s_ctlfd);
     pipefd = atoi(s_pipe);
     ppid = atoi(s_pid);
-    x = 0;
-#ifndef _WIN32
-    for(x = 0; x < maxfd; x++) {
-        if(x != ctlfd && x != pipefd && x > 2)
-            close(x);
-    }
-    x = open("/dev/null", O_RDWR);
-
-    if(x >= 0) {
-        if(ctlfd != 0 && pipefd != 0)
-            dup2(x, 0);
-        if(ctlfd != 1 && pipefd != 1)
-            dup2(x, 1);
-        if(ctlfd != 2 && pipefd != 2)
-            dup2(x, 2);
-        if(x > 2)
-            close(x);
-    }
-#endif
     setup_signals();
     rb_lib_init(NULL, NULL, NULL, maxfd, 1024, 4096);
     rb_init_rawbuffers(1024);

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -1120,7 +1120,7 @@ main(int argc, char **argv)
     }
 #endif
     setup_signals();
-    rb_lib_init(NULL, NULL, NULL, 0, maxfd, 1024, 4096);
+    rb_lib_init(NULL, NULL, NULL, maxfd, 1024, 4096);
     rb_init_rawbuffers(1024);
     ssl_ok = rb_supports_ssl();
     mod_ctl = rb_malloc(sizeof(mod_ctl_t));

--- a/testsuite/ircd.conf.1
+++ b/testsuite/ircd.conf.1
@@ -44,7 +44,7 @@ auth { user = "*@127.0.0.0/8"; class = "users"; };
 
 operator "oper" {
 	user = "*@127.0.0.0/8";
-	password = "$6$J1wnaIKDnaY/jtEM$K7hHBMZ58qXEB8W1qlWuNuN3z0yjYjB/vWGGdpEdjdivnm6p.F3bmYqmjCj4iviEvF7e.nebHaHG6XXaCD9Gm0";
+	password = "testsuite";
 	flags = ~encrypted;
 };
 

--- a/testsuite/ircd.conf.1
+++ b/testsuite/ircd.conf.1
@@ -20,7 +20,7 @@ serverinfo {
 
 admin {
 	name = "Here";
-	description = "Charybdis testsuite server";
+	description = "Elemental testsuite server";
 	email = "root@localhost";
 };
 
@@ -44,9 +44,8 @@ auth { user = "*@127.0.0.0/8"; class = "users"; };
 
 operator "oper" {
 	user = "*@127.0.0.0/8";
-	password = "oper"; 
-	flags = global_kill, remote, kline, unkline, nick_changes,
-		die, rehash, admin, xline, operwall, oper_spy, ~encrypted;
+	password = "$6$J1wnaIKDnaY/jtEM$K7hHBMZ58qXEB8W1qlWuNuN3z0yjYjB/vWGGdpEdjdivnm6p.F3bmYqmjCj4iviEvF7e.nebHaHG6XXaCD9Gm0";
+	flags = ~encrypted;
 };
 
 connect "testsuite2." {

--- a/testsuite/ircd.conf.2
+++ b/testsuite/ircd.conf.2
@@ -44,7 +44,7 @@ auth { user = "*@127.0.0.0/8"; class = "users"; };
 
 operator "oper" {
 	user = "*@127.0.0.0/8";
-	password = "$6$J1wnaIKDnaY/jtEM$K7hHBMZ58qXEB8W1qlWuNuN3z0yjYjB/vWGGdpEdjdivnm6p.F3bmYqmjCj4iviEvF7e.nebHaHG6XXaCD9Gm0";
+	password = "testsuite";
 	flags = ~encrypted;
 };
 

--- a/testsuite/ircd.conf.2
+++ b/testsuite/ircd.conf.2
@@ -20,7 +20,7 @@ serverinfo {
 
 admin {
 	name = "Here";
-	description = "Charybdis testsuite server";
+	description = "Elemental testsuite server";
 	email = "root@localhost";
 };
 
@@ -44,9 +44,8 @@ auth { user = "*@127.0.0.0/8"; class = "users"; };
 
 operator "oper" {
 	user = "*@127.0.0.0/8";
-	password = "oper"; 
-	flags = global_kill, remote, kline, unkline, nick_changes,
-		die, rehash, admin, xline, operwall, oper_spy, ~encrypted;
+	password = "$6$J1wnaIKDnaY/jtEM$K7hHBMZ58qXEB8W1qlWuNuN3z0yjYjB/vWGGdpEdjdivnm6p.F3bmYqmjCj4iviEvF7e.nebHaHG6XXaCD9Gm0";
+	flags = ~encrypted;
 };
 
 connect "testsuite1." {

--- a/testsuite/ircd.conf.3
+++ b/testsuite/ircd.conf.3
@@ -44,7 +44,7 @@ auth { user = "*@127.0.0.0/8"; class = "users"; };
 
 operator "oper" {
 	user = "*@127.0.0.0/8";
-	password = "$6$J1wnaIKDnaY/jtEM$K7hHBMZ58qXEB8W1qlWuNuN3z0yjYjB/vWGGdpEdjdivnm6p.F3bmYqmjCj4iviEvF7e.nebHaHG6XXaCD9Gm0";
+	password = "testsuite";
 	flags = ~encrypted;
 };
 

--- a/testsuite/ircd.conf.3
+++ b/testsuite/ircd.conf.3
@@ -20,7 +20,7 @@ serverinfo {
 
 admin {
 	name = "Here";
-	description = "Charybdis testsuite server";
+	description = "Elemental testsuite server";
 	email = "root@localhost";
 };
 
@@ -44,9 +44,8 @@ auth { user = "*@127.0.0.0/8"; class = "users"; };
 
 operator "oper" {
 	user = "*@127.0.0.0/8";
-	password = "oper"; 
-	flags = global_kill, remote, kline, unkline, nick_changes,
-		die, rehash, admin, xline, operwall, oper_spy, ~encrypted;
+	password = "$6$J1wnaIKDnaY/jtEM$K7hHBMZ58qXEB8W1qlWuNuN3z0yjYjB/vWGGdpEdjdivnm6p.F3bmYqmjCj4iviEvF7e.nebHaHG6XXaCD9Gm0";
+	flags = ~encrypted;
 };
 
 connect "testsuite1." {

--- a/testsuite/runtest.sh
+++ b/testsuite/runtest.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+#TODO: Test more than startup
+
+source ./startall.sh
+
+sleep 5
+
+ircd1=`<ircd.pid.1`
+ircd2=`<ircd.pid.2`
+ircd3=`<ircd.pid.3`
+
+kill $ircd1 $ircd2 $ircd3
+
+wait "0${ircd1}"
+ecode1=$?
+
+wait "0${ircd2}"
+ecode2=$?
+
+wait "0${ircd3}"
+ecode3=$?
+
+if [ x"000" != x"${ecode1}${ecode2}${ecode3}" ]; then
+    echo "Non-zero exit code"
+    echo "ircd 1: ${ecode1}"
+    echo "ircd 2: ${ecode2}"
+    echo "ircd 3: ${ecode3}"
+    exit 1
+fi
+
+echo "Test ok!"
+
+exit 0

--- a/testsuite/startall.sh
+++ b/testsuite/startall.sh
@@ -3,6 +3,6 @@ testdir=`pwd`
 prefix=`sed -n -e 's/^#define IRCD_PREFIX "\(.*\)"/\1/p' "$testdir/../include/setup.h"`
 [ -d $prefix ] || { echo Unable to find installation prefix; exit 1; }
 
-$prefix/bin/ircd -configfile $testdir/ircd.conf.1 -pidfile $testdir/ircd.pid.1
-$prefix/bin/ircd -configfile $testdir/ircd.conf.2 -pidfile $testdir/ircd.pid.2
-$prefix/bin/ircd -configfile $testdir/ircd.conf.3 -pidfile $testdir/ircd.pid.3
+$prefix/bin/ircd -configfile $testdir/ircd.conf.1 -pidfile $testdir/ircd.pid.1 -foreground -logfile /dev/stdout &
+$prefix/bin/ircd -configfile $testdir/ircd.conf.2 -pidfile $testdir/ircd.pid.2 -foreground -logfile /dev/stdout &
+$prefix/bin/ircd -configfile $testdir/ircd.conf.3 -pidfile $testdir/ircd.pid.3 -foreground -logfile /dev/stdout &


### PR DESCRIPTION
adds rb_set_inherit and makes every fd added to the event loop default to not inherited

test 'suite' just checks that starting and linking ircd's doesn't crash anything, nothing more than that, but more can be added