### PR TITLE
Fix ambiguity of 482 replies

### DIFF
--- a/extensions/m_findforwards.c
+++ b/extensions/m_findforwards.c
@@ -70,7 +70,7 @@ m_findforwards(struct Client *client_p, struct Client *source_p, int parc, const
         }
 
         if(!is_any_op(msptr)) {
-            sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+            sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                        me.name, source_p->name, parv[1]);
             return 0;
         }

--- a/include/numeric.h
+++ b/include/numeric.h
@@ -294,7 +294,7 @@ extern const char *form_str(int);
 #define ERR_THROTTLE         480
 
 #define ERR_NOPRIVILEGES     481
-#define ERR_CHANOPRIVSNEEDED 482
+#define ERR_CHANPRIVSNEEDED 482
 #define ERR_CANTKILLSERVER   483
 #define ERR_ISCHANSERVICE    484
 /* #define ERR_RESTRICTED       484 	- hyb derived, no longer here */

--- a/modules/core/m_kick.c
+++ b/modules/core/m_kick.c
@@ -115,7 +115,7 @@ m_kick(struct Client *client_p, struct Client *source_p, int parc, const char *p
 
             /* If its a TS 0 channel, do it the old way */
             else if(chptr->channelts == 0) {
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            get_id(&me, source_p), get_id(source_p, source_p), name);
                 return 0;
             }

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -351,7 +351,7 @@ build_target_list(enum message_type msgtype, struct Client *client_p,
                 msptr = find_channel_membership(chptr, source_p);
 
                 if(!IsServer(source_p) && !IsService(source_p) && !is_chanop_voiced(msptr)) {
-                    sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                    sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                                get_id(&me, source_p),
                                get_id(source_p, source_p),
                                with_prefix);

--- a/modules/m_invite.c
+++ b/modules/m_invite.c
@@ -146,7 +146,7 @@ m_invite(struct Client *client_p, struct Client *source_p, int parc, const char 
                           ":%s WALLOPS :%s is overriding INVITE [%s] on [%s]",
                           me.name, get_oper_name(source_p), target_p->name, chptr->chname);
         } else {
-            sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+            sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                        me.name, source_p->name, parv[2]);
             return 0;
         }

--- a/modules/m_topic.c
+++ b/modules/m_topic.c
@@ -127,7 +127,7 @@ m_topic(struct Client *client_p, struct Client *source_p, int parc, const char *
                               ":%s WALLOPS :%s is overriding TOPIC on [%s]",
                               me.name, get_oper_name(source_p), chptr->chname);
             } else {
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, parv[1]);
                 return 0;
             }

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -531,7 +531,7 @@ chm_simple(struct Client *source_p, struct Channel *chptr,
             override = 1;
         else {
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -722,7 +722,7 @@ chm_staff(struct Client *source_p, struct Channel *chptr,
             override = 1;
         else {
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -854,7 +854,7 @@ chm_ban(struct Client *source_p, struct Channel *chptr,
             } else {
 
                 if(!(*errors & SM_ERR_NOOPS))
-                    sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                    sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                                me.name, source_p->name, chptr->chname);
                 *errors |= SM_ERR_NOOPS;
                 return;
@@ -880,7 +880,7 @@ chm_ban(struct Client *source_p, struct Channel *chptr,
         else {
 
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -1168,7 +1168,7 @@ chm_op(struct Client *source_p, struct Channel *chptr,
         else {
 
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -1270,7 +1270,7 @@ chm_halfop(struct Client *source_p, struct Channel *chptr,
         else {
 
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -1364,7 +1364,7 @@ chm_voice(struct Client *source_p, struct Channel *chptr,
         else {
 
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -1442,7 +1442,7 @@ chm_limit(struct Client *source_p, struct Channel *chptr,
             override = 1;
         else {
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -1505,7 +1505,7 @@ chm_throttle(struct Client *source_p, struct Channel *chptr,
         else {
 
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -1589,7 +1589,7 @@ chm_forward(struct Client *source_p, struct Channel *chptr,
             override = 1;
         else {
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
@@ -1635,7 +1635,7 @@ chm_forward(struct Client *source_p, struct Channel *chptr,
                 if(IsOverride(source_p))
                     override = 1;
                 else {
-                    sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                    sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                                me.name, source_p->name, targptr->chname);
                     return;
                 }
@@ -1682,7 +1682,7 @@ chm_key(struct Client *source_p, struct Channel *chptr,
             override = 1;
         else {
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, form_str(ERR_CHANOPRIVSNEEDED),
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED),
                            me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;

--- a/src/chmode.c
+++ b/src/chmode.c
@@ -975,7 +975,7 @@ chm_owner(struct Client *source_p, struct Channel *chptr,
             override = 1;
         else {
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, ":%s 482 %s %s :You're not a channel owner", me.name, source_p->name, chptr->chname);
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED), me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
         }
@@ -1075,7 +1075,7 @@ chm_admin(struct Client *source_p, struct Channel *chptr,
         else {
 
             if(!(*errors & SM_ERR_NOOPS))
-                sendto_one(source_p, ":%s 482 %s %s :You're not a channel administrator", me.name, source_p->name, chptr->chname);
+                sendto_one(source_p, form_str(ERR_CHANPRIVSNEEDED), me.name, source_p->name, chptr->chname);
             *errors |= SM_ERR_NOOPS;
             return;
         }

--- a/src/messages.tab
+++ b/src/messages.tab
@@ -503,7 +503,7 @@ static  const char *  replies[] = {
 /* 479 ERR_BADCHANNAME */       "%s :Illegal channel name",
 /* 480 ERR_THROTTLE */          ":%s 480 %s %s :Cannot join channel (+j) - throttle exceeded, try again later",
 /* 481 ERR_NOPRIVILEGES, */	":Permission Denied - You're not an IRC operator",
-/* 482 ERR_CHANOPRIVSNEEDED, */ ":%s 482 %s %s :You're not a channel operator",
+/* 482 ERR_CHANPRIVSNEEDED, */ ":%s 482 %s %s :You don't have permission to do that",
 /* 483 ERR_CANTKILLSERVER, */   ":You can't kill a server!",
 /* 484 ERR_ISCHANSERVICE */     ":%s 484 %s %s %s :Cannot kick or deop a network service",
 /* 485 ERR_BANNEDNICK, */	NULL,


### PR DESCRIPTION
482 is being used for more than just chanop status. This makes things more generic, yo.