### PR TITLE
Add RPL_YOURID for showing the client's UID on connect

### DIFF
--- a/include/numeric.h
+++ b/include/numeric.h
@@ -51,6 +51,7 @@ extern const char *form_str(int);
 #define RPL_MAP		     15	/* Undernet extension */
 #define RPL_MAPMORE	     16	/* Undernet extension */
 #define RPL_MAPEND	     17	/* Undernet extension */
+#define RPL_YOURID       42 /* From ircnet */
 #define RPL_SAVENICK         43 /* From ircnet */
 
 /*

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -87,4 +87,5 @@ automod_LTLIBRARIES =     \
     m_who.la              \
     m_whowas.la           \
     m_xline.la            \
+    m_yourid.la           \
     sno_routing.la

--- a/modules/m_yourid.c
+++ b/modules/m_yourid.c
@@ -1,0 +1,33 @@
+/*
+ * Elemental-IRCd: Internet Relay Chat Program Server
+ * m_yourid.c: show a client's unique ID on connect, ircd 2.11 style
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "hash.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+
+static void check_new_user(void *data);
+
+mapi_hfn_list_av1 m_yourip_hfnlist[] = {
+    { "new_local_user", (hookfn) check_new_user },
+    { NULL, NULL }
+};
+
+DECLARE_MODULE_AV1(m_yourip, NULL, NULL, NULL, NULL,
+                   m_yourip_hfnlist, "$Revision$");
+
+static void
+check_new_user(void *vdata)
+{
+    struct Client *source_p = (void *)vdata;
+    sendto_one_numeric(source_p, RPL_YOURID, form_str(RPL_YOURID), source_p->id);
+}

--- a/src/messages.tab
+++ b/src/messages.tab
@@ -60,7 +60,7 @@ static  const char *  replies[] = {
 /* 039 */       NULL,
 /* 040 */       NULL,
 /* 041 */       NULL,
-/* 042 */       NULL,
+/* 042 RPL_YOURID */       "%s :Your unique ID",
 /* 043 RPL_SAVENICK */       "%s :Nick collision, forcing nick change to your unique ID",
 /* 044 */       NULL,
 /* 045 */       NULL,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,4 +11,5 @@ TESTS = away-notify.tcl \
         omode.tcl \
         privmsg.tcl \
         register.tcl \
-        umodeg.tcl
+        umodeg.tcl \
+        yourid.tcl

--- a/tests/lib/numeric.tcl
+++ b/tests/lib/numeric.tcl
@@ -47,6 +47,7 @@ def_numeric RPL_REDIR               {010}
 def_numeric RPL_MAP                 {015}
 def_numeric RPL_MAPMORE             {016}
 def_numeric RPL_MAPEND              {017}
+def_numeric RPL_YOURID              {042}
 def_numeric RPL_SAVENICK            {043}
 
 def_numeric RPL_TRACELINK           {200}

--- a/tests/yourid.tcl
+++ b/tests/yourid.tcl
@@ -1,0 +1,5 @@
+begin {Ensure that 042 gets sent on login}
+
+client yourid
+
+<< $RPL_YOURID


### PR DESCRIPTION
This is a pointless thing to hide and will be useful for the TS6 test suite.