### PR TITLE
m_omode: remove restriction forbidding opped users from using OMODE

### DIFF
--- a/extensions/m_omode.c
+++ b/extensions/m_omode.c
@@ -90,11 +90,6 @@ mo_omode(struct Client *client_p, struct Client *source_p, int parc, const char 
     msptr = find_channel_membership(chptr, source_p);
     wasonchannel = msptr != NULL;
 
-    if (is_any_op(msptr)) {
-        sendto_one_notice(source_p, ":Use a normal MODE you idiot");
-        return 0;
-    }
-
     params[0] = '\0';
     for (i = 2; i < parc; i++) {
         if (i != 2)

--- a/help/opers/omode
+++ b/help/opers/omode
@@ -2,5 +2,4 @@ OMODE <#channel> <mode(s)> [parameters]
 
 -- Allows opers to arbitrarily set modes on channels.
 This command allows opers to set/change modes on channels
-that they do not have ops in. This command fails if a oper
-uses it on a channel they do have ops in.
+that they do not have ops in.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,6 +8,7 @@ TESTS = away-notify.tcl \
         echo-message.tcl \
         metadata.tcl \
         monitor.tcl \
+        omode.tcl \
         privmsg.tcl \
         register.tcl \
         umodeg.tcl

--- a/tests/omode.tcl
+++ b/tests/omode.tcl
@@ -7,8 +7,11 @@ client oper
 oper :
     # set up m_omode.so
     >> OPER god testsuite
+    << $RPL_YOUREOPER
     >> MODLOAD extensions/m_omode.so
-    << NOTICE * "*** Notice -- Module m_omode.so \[version: \$Revision\$; MAPI version: 1\] loaded at"
+
+    # sleep a little just in case
+    after 125
 
     >> MODE [oper nick] +p
     << MODE [oper nick] +p

--- a/tests/omode.tcl
+++ b/tests/omode.tcl
@@ -5,13 +5,16 @@ set test_channel #omode
 client oper
 
 oper :
+    # set up m_omode.so
     >> OPER god testsuite
     >> MODLOAD extensions/m_omode.so
-    << omode.so
+    << NOTICE * "*** Notice -- Module m_omode.so \[version: \$Revision\$; MAPI version: 1\] loaded at"
 
     >> MODE [oper nick] +p
-    << MODE
+    << MODE [oper nick] +p
     >> MODE $test_channel +h [oper nick]
-    << MODE
+    << MODE $test_channel +h [oper nick]
     >> OMODE $test_channel +y [oper nick]
-    << MODE
+    << MODE $test_channel +y [oper nick]
+
+    >> MODUNLOAD m_omode.so

--- a/tests/omode.tcl
+++ b/tests/omode.tcl
@@ -1,0 +1,17 @@
+begin {Check OMODE changes}
+
+set test_channel #omode
+
+client oper
+
+oper :
+    >> OPER god testsuite
+    >> MODLOAD extensions/m_omode.so
+    << omode.so
+
+    >> MODE [oper nick] +p
+    << MODE
+    >> MODE $test_channel +h [oper nick]
+    << MODE
+    >> OMODE $test_channel +y [oper nick]
+    << MODE


### PR DESCRIPTION
This is really broken with the introduction of `~!%`. When you have `%`, for example, there is no way to give yourself greater access, and no way to remove the mode either. `OMODE` becomes sort of one-way when setting certain modes on yourself, which isn't intuitive at all.

Imports GLolol/elemental-ircd@2b3f67eb8ae428803b74a5a0bcec739a7eabac09

Thanks @GLolol!