### PR TITLE
Add autoconf-archive to the Ubuntu packages to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For an easy one-step install:
 ### Ubuntu/Debian
 
 ```console
-$ sudo apt-get install libssl-dev autoconf build-essential flex bison libsqlite3-dev automake libtool
+$ sudo apt-get install libssl-dev autoconf autoconf-archive build-essential flex bison libsqlite3-dev automake libtool
 ```
 
 ### Fedora/CentOS


### PR DESCRIPTION
I was getting errors I couldn't figure out, and it took a while to figure out that the AX macros are part of autoconf-archive. This makes sure that people will install it when they first set up elemental.