### PR TITLE
Revert "Don't use --force on autoreconf"

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,5 +3,5 @@
 set -e
 
 autoreconf --version
-autoreconf --install --verbose --warnings=portability,no-unsupported
+autoreconf --install --verbose --force --warnings=portability,no-unsupported
 scripts/version.sh


### PR DESCRIPTION
This reverts commit a0a8d5bda12da4ad85a009e40b9253caad1e994f.

It broke builds with libtool >= 2.4.4