### PR TITLE
Remove ziplinks and some cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,29 +180,6 @@ else
 	 AC_DEFINE([HAVE_NANOSLEEP], 1, [Define if nanosleep exists])
 fi
 
-dnl Specialized functions and libraries
-dnl ===================================
-
-AC_ARG_WITH(zlib-path,
-AS_HELP_STRING([--with-zlib-path=DIR],[Path to libz.so for ziplinks support.]),
-[LIBS="$LIBS -L$withval"],)
-
-AC_ARG_ENABLE(zlib,
-AS_HELP_STRING([--disable-zlib],[Disable ziplinks support]),
-[zlib=$enableval],[zlib=yes])
-
-if test "$zlib" = yes; then
-
-AC_CHECK_HEADER(zlib.h, [
-	AC_CHECK_LIB(z, zlibVersion,
-	[
-		AC_SUBST(ZLIB_LD, -lz)
-		AC_DEFINE(HAVE_LIBZ, 1, [Define to 1 if zlib (-lz) is available.])
-	], zlib=no)
-], zlib=no)
-
-fi
-
 dnl **********************************************************************
 dnl --with-confdir Deprecated, use --sysconfdir
 dnl **********************************************************************
@@ -455,7 +432,6 @@ echo "
 Configuration:
 	Install directory  : $prefix
 
-	Ziplinks           : $zlib
 	Small network      : $small_net
 	Block allocator    : $balloc
 

--- a/doc/reference.charybdis.conf
+++ b/doc/reference.charybdis.conf
@@ -590,7 +590,6 @@ connect "irc.uplink.com" {
 	/* flags: controls special options for this server
 	 * encrypted	- marks the accept_password as being crypt()'d
 	 * autoconn	- automatically connect to this server
-	 * compressed	- compress traffic via ziplinks
 	 * topicburst	- burst topics between servers
 	 * ssl		- ssl/tls encrypted server connections
 	 */

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -595,7 +595,6 @@ connect "irc.uplink.com" {
 	/* flags: controls special options for this server
 	 * encrypted	- marks the accept_password as being crypt()'d
 	 * autoconn	- automatically connect to this server
-	 * compressed	- compress traffic via ziplinks
 	 * topicburst	- burst topics between servers
 	 * ssl		- ssl/tls encrypted server connections
 	 */

--- a/doc/sgml/oper-guide/commands.sgml
+++ b/doc/sgml/oper-guide/commands.sgml
@@ -1095,12 +1095,6 @@
 	    </listitem>
 	  </varlistentry>
 	  <varlistentry>
-	    <term>Z</term>
-	    <listitem>
-	      <para>Show ziplinks statistics</para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry>
 	    <term>?</term>
 	    <listitem>
 	      <para>Show connected servers and link information about them</para>

--- a/doc/sgml/oper-guide/config.sgml
+++ b/doc/sgml/oper-guide/config.sgml
@@ -695,16 +695,6 @@ connect "<replaceable>name</replaceable>" {
 	    </listitem>
 	  </varlistentry>
 	  <varlistentry>
-	    <term>compressed</term>
-	    <listitem>
-	      <para>Ziplinks should be used with this server connection.
-	      This compresses traffic using zlib, saving some bandwidth
-	      and speeding up netbursts.</para>
-	      <para>If you have trouble setting up a link, you should
-	      turn this off as it often hides error messages.</para>
-	    </listitem>
-	  </varlistentry>
-	  <varlistentry>
 	    <term>topicburst</term>
 	    <listitem>
 	      <para>Topics should be bursted to this server.</para>

--- a/help/opers/stats
+++ b/help/opers/stats
@@ -40,5 +40,4 @@ X f - Shows File Descriptors
 * X - Shows gecos bans (Old X: lines)
 ^ y - Shows connection classes (Old Y: lines)
 * z - Shows memory stats
-* Z - Shows ziplinks stats
 ^ ? - Shows connected servers and sendq info about them

--- a/include/client.h
+++ b/include/client.h
@@ -97,15 +97,6 @@ struct Server {
     struct scache_entry *nameinfo;
 };
 
-struct ZipStats {
-    unsigned long long in;
-    unsigned long long in_wire;
-    unsigned long long out;
-    unsigned long long out_wire;
-    double in_ratio;
-    double out_ratio;
-};
-
 struct Client {
     rb_dlink_node node;
     rb_dlink_node lnode;
@@ -270,9 +261,7 @@ struct LocalUser {
 			      applicable to this client */
 
     struct _ssl_ctl *ssl_ctl;		/* which ssl daemon we're associate with */
-    struct _ssl_ctl *z_ctl;			/* second ctl for ssl+zlib */
     uint32_t localflags;
-    struct ZipStats *zipstats;		/* zipstats */
     uint16_t cork_count;			/* used for corking/uncorking connections */
     struct ev_entry *event;			/* used for associated events */
 

--- a/include/ircd.h
+++ b/include/ircd.h
@@ -106,7 +106,6 @@ extern int testing_conf;
 extern struct ev_entry *check_splitmode_ev;
 
 extern int ssl_ok;
-extern int zlib_ok;
 extern int maxconnections;
 
 int ircd_main(int argc, char *argv[]);

--- a/include/m_info.h
+++ b/include/m_info.h
@@ -130,11 +130,6 @@ Info MyInformation[] = {
         "Anti SpamBot Parameter"
     },
 
-#ifdef HAVE_LIBZ
-    {"HAVE_LIBZ", "YES", 0, "zlib (ziplinks) support"},
-#else
-    {"HAVE_LIBZ", "NO", 0, "zlib (ziplinks)  support"},
-#endif /* HAVE_LIBZ */
 
 #ifdef PPATH
     {"PPATH", PPATH, 0, "Path to Pid File"},

--- a/include/s_serv.h
+++ b/include/s_serv.h
@@ -79,11 +79,7 @@ struct Capability {
 			 CAP_RSFNC | CAP_SAVE | CAP_EUID | CAP_EOPMOD | \
 			 CAP_BAN | CAP_MLOCK)
 
-#ifdef HAVE_LIBZ
-#define CAP_ZIP_SUPPORTED       CAP_ZIP
-#else
 #define CAP_ZIP_SUPPORTED       0
-#endif
 
 /*
  * Capability macros.

--- a/include/sslproc.h
+++ b/include/sslproc.h
@@ -30,7 +30,6 @@ void init_ssld(void);
 int start_ssldaemon(int count, const char *ssl_cert, const char *ssl_private_key, const char *ssl_dh_params);
 ssl_ctl_t *start_ssld_accept(rb_fde_t *sslF, rb_fde_t *plainF, int id);
 ssl_ctl_t *start_ssld_connect(rb_fde_t *sslF, rb_fde_t *plainF, int id);
-void start_zlib_session(void *data);
 void send_new_ssl_certs(const char *ssl_cert, const char *ssl_private_key, const char *ssl_dh_params);
 void ssld_decrement_clicount(ssl_ctl_t *ctl);
 int get_ssld_count(void);

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -116,7 +116,6 @@ static void stats_class(struct Client *);
 static void stats_memory(struct Client *);
 static void stats_servlinks(struct Client *);
 static void stats_ltrace(struct Client *, int, const char **);
-static void stats_ziplinks(struct Client *);
 static void stats_comm(struct Client *);
 /* This table contains the possible stats items, in order:
  * stats letter,  function to call, operonly? adminonly?
@@ -167,7 +166,6 @@ static struct StatsStruct stats_cmd_table[] = {
     {'y', stats_class,		0, 0, },
     {'Y', stats_class,		0, 0, },
     {'z', stats_memory,		1, 0, },
-    {'Z', stats_ziplinks,		1, 0, },
     {'?', stats_servlinks,		0, 0, },
     {(char) 0, (void (*)()) 0, 	0, 0, }
 };
@@ -1298,36 +1296,6 @@ stats_memory (struct Client *source_p)
                        "z :Remote client Memory in use: %ld(%ld)",
                        (long)remote_client_count,
                        (long)remote_client_memory_used);
-}
-
-static void
-stats_ziplinks (struct Client *source_p)
-{
-    rb_dlink_node *ptr;
-    struct Client *target_p;
-    struct ZipStats *zipstats;
-    int sent_data = 0;
-    char buf[128], buf1[128];
-    RB_DLINK_FOREACH (ptr, serv_list.head) {
-        target_p = ptr->data;
-        if(IsCapable (target_p, CAP_ZIP)) {
-            zipstats = target_p->localClient->zipstats;
-            sprintf(buf, "%.2f%%", zipstats->out_ratio);
-            sprintf(buf1, "%.2f%%", zipstats->in_ratio);
-            sendto_one_numeric(source_p, RPL_STATSDEBUG,
-                               "Z :ZipLinks stats for %s send[%s compression "
-                               "(%llu kB data/%llu kB wire)] recv[%s compression "
-                               "(%llu kB data/%llu kB wire)]",
-                               target_p->name,
-                               buf, zipstats->out >> 10,
-                               zipstats->out_wire >> 10, buf1,
-                               zipstats->in >> 10, zipstats->in_wire >> 10);
-            sent_data++;
-        }
-    }
-
-    sendto_one_numeric(source_p, RPL_STATSDEBUG,
-                       "Z :%u ziplink(s)", sent_data);
 }
 
 static void

--- a/modules/m_version.c
+++ b/modules/m_version.c
@@ -134,10 +134,6 @@ confopts(struct Client *source_p)
     *p++ = 'T';
 #endif
 
-#ifdef HAVE_LIBZ
-    *p++ = 'Z';
-#endif
-
 #ifdef RB_IPV6
     *p++ = '6';
 #endif

--- a/src/client.c
+++ b/src/client.c
@@ -239,9 +239,6 @@ free_local_client(struct Client *client_p)
     if(IsSSL(client_p))
         ssld_decrement_clicount(client_p->localClient->ssl_ctl);
 
-    if(IsCapable(client_p, CAP_ZIP))
-        ssld_decrement_clicount(client_p->localClient->z_ctl);
-
     rb_bh_free(lclient_heap, client_p->localClient);
     client_p->localClient = NULL;
 }

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -103,7 +103,6 @@ int kline_queued = 0;
 int server_state_foreground = 0;
 int opers_see_all_users = 0;
 int ssl_ok = 0;
-int zlib_ok = 1;
 
 int testing_conf = 0;
 time_t startup_time;

--- a/src/listener.c
+++ b/src/listener.c
@@ -451,6 +451,7 @@ accept_precallback(rb_fde_t *F, struct sockaddr *addr, rb_socklen_t addrlen, voi
     static time_t last_oper_notice = 0;
     int len;
 
+    /* connection on an ssl port, but we cant ssl */
     if(listener->ssl && (!ssl_ok || !get_ssld_count())) {
         rb_close(F);
         return 0;

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -1192,13 +1192,6 @@ conf_end_connect(struct TopConf *tc)
         return 0;
     }
 
-#ifndef HAVE_LIBZ
-    if(ServerConfCompressed(yy_server)) {
-        conf_report_error("Ignoring connect::flags::compressed -- zlib not available.");
-        yy_server->flags &= ~SERVER_COMPRESSED;
-    }
-#endif
-
     add_server_conf(yy_server);
     rb_dlinkAdd(yy_server, &yy_server->node, &server_conf_list);
 
@@ -1476,18 +1469,7 @@ conf_set_general_stats_i_oper_only(void *data)
 static void
 conf_set_general_compression_level(void *data)
 {
-#ifdef HAVE_LIBZ
-    ConfigFileEntry.compression_level = *(unsigned int *) data;
-
-    if((ConfigFileEntry.compression_level < 1) || (ConfigFileEntry.compression_level > 9)) {
-        conf_report_error
-        ("Invalid general::compression_level %d -- using default.",
-         ConfigFileEntry.compression_level);
-        ConfigFileEntry.compression_level = 0;
-    }
-#else
     conf_report_error("Ignoring general::compression_level -- zlib not available.");
-#endif
 }
 
 static void

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -724,10 +724,6 @@ set_default_conf(void)
     ConfigFileEntry.secret_channels_in_whois = NO;
     ConfigFileEntry.away_interval = 30;
 
-#ifdef HAVE_LIBZ
-    ConfigFileEntry.compression_level = 4;
-#endif
-
     ConfigFileEntry.oper_umodes = UMODE_LOCOPS | UMODE_SERVNOTICE |
                                   UMODE_OPERWALL | UMODE_WALLOP;
     ConfigFileEntry.oper_only_umodes = UMODE_SERVNOTICE;

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -339,12 +339,8 @@ check_server(const char *name, struct Client *client_p)
 
     attach_server_conf(client_p, server_p);
 
-    /* clear ZIP/TB if they support but we dont want them */
-#ifdef HAVE_LIBZ
-    server_test = !ServerConfCompressed(server_p);
-#endif
-    if (server_test)
-        ClearCap(client_p, CAP_ZIP);
+    /* clear ZIP/TB, no support on our side */
+    ClearCap(client_p, CAP_ZIP);
 
     if(!ServerConfTb(server_p))
         ClearCap(client_p, CAP_TB);
@@ -780,10 +776,6 @@ server_estab(struct Client *client_p)
     if(!rb_set_buffers(client_p->localClient->F, READBUF_SIZE))
         ilog_error("rb_set_buffers failed for server");
 
-    /* Enable compression now */
-    if(IsCapable(client_p, CAP_ZIP)) {
-        start_zlib_session(client_p);
-    }
     sendto_one(client_p, "SVINFO %d %d 0 :%ld", TS_CURRENT, TS_MIN, (long int)rb_current_time());
 
     client_p->servptr = &me;

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -34,9 +34,6 @@
 #include "send.h"
 #include "packet.h"
 
-#define ZIPSTATS_TIME           60
-
-static void collect_zipstats(void *unused);
 static void ssl_read_ctl(rb_fde_t * F, void *data);
 static int ssld_count;
 
@@ -315,37 +312,6 @@ start_ssldaemon(int count, const char *ssl_cert, const char *ssl_private_key, co
 }
 
 static void
-ssl_process_zipstats(ssl_ctl_t * ctl, ssl_ctl_buf_t * ctl_buf)
-{
-    struct Client *server;
-    struct ZipStats *zips;
-    char *parv[7];
-    rb_string_to_array(ctl_buf->buf, parv, 6);
-    server = find_server(NULL, parv[1]);
-    if(server == NULL || server->localClient == NULL || !IsCapable(server, CAP_ZIP))
-        return;
-    if(server->localClient->zipstats == NULL)
-        server->localClient->zipstats = rb_malloc(sizeof(struct ZipStats));
-
-    zips = server->localClient->zipstats;
-
-    zips->in += strtoull(parv[2], NULL, 10);
-    zips->in_wire += strtoull(parv[3], NULL, 10);
-    zips->out += strtoull(parv[4], NULL, 10);
-    zips->out_wire += strtoull(parv[5], NULL, 10);
-
-    if(zips->in > 0)
-        zips->in_ratio = ((double) (zips->in - zips->in_wire) / (double) zips->in) * 100.00;
-    else
-        zips->in_ratio = 0;
-
-    if(zips->out > 0)
-        zips->out_ratio = ((double) (zips->out - zips->out_wire) / (double) zips->out) * 100.00;
-    else
-        zips->out_ratio = 0;
-}
-
-static void
 ssl_process_dead_fd(ssl_ctl_t * ctl, ssl_ctl_buf_t * ctl_buf)
 {
     struct Client *client_p;
@@ -403,7 +369,7 @@ static void
 ssl_process_cmd_recv(ssl_ctl_t * ctl)
 {
     static const char *cannot_setup_ssl = "ssld cannot setup ssl, check your certificates and private key";
-    static const char *no_ssl_or_zlib = "ssld has neither SSL/TLS or zlib support killing all sslds";
+    static const char *no_ssl = "ssld has no SSL/TLS support killing all sslds";
     rb_dlink_node *ptr, *next;
     ssl_ctl_buf_t *ctl_buf;
     if(ctl->dead)
@@ -420,22 +386,15 @@ ssl_process_cmd_recv(ssl_ctl_t * ctl)
         case 'F':
             ssl_process_certfp(ctl, ctl_buf);
             break;
-        case 'S':
-            ssl_process_zipstats(ctl, ctl_buf);
-            break;
         case 'I':
             ssl_ok = 0;
             ilog(L_MAIN, cannot_setup_ssl);
             sendto_realops_snomask(SNO_GENERAL, L_ALL, cannot_setup_ssl);
         case 'U':
-            zlib_ok = 0;
             ssl_ok = 0;
-            ilog(L_MAIN, no_ssl_or_zlib);
-            sendto_realops_snomask(SNO_GENERAL, L_ALL, no_ssl_or_zlib);
+            ilog(L_MAIN, no_ssl);
+            sendto_realops_snomask(SNO_GENERAL, L_ALL, no_ssl);
             ssl_killall();
-            break;
-        case 'z':
-            zlib_ok = 0;
             break;
         default:
             ilog(L_MAIN, "Received invalid command from ssld: %s", ctl_buf->buf);
@@ -664,123 +623,6 @@ ssld_decrement_clicount(ssl_ctl_t * ctl)
     }
 }
 
-/*
- * what we end up sending to the ssld process for ziplinks is the following
- * Z[ourfd][level][RECVQ]
- * Z = ziplinks command	= buf[0]
- * ourfd = Our end of the socketpair = buf[1..4]
- * level = zip level buf[5]
- * recvqlen = our recvq len = buf[6-7]
- * recvq = any data we read prior to starting ziplinks
- */
-void
-start_zlib_session(void *data)
-{
-    struct Client *server = (struct Client *) data;
-    uint16_t recvqlen;
-    uint8_t level;
-    void *xbuf;
-
-    rb_fde_t *F[2];
-    rb_fde_t *xF1, *xF2;
-    char *buf;
-    char buf2[9];
-    void *recvq_start;
-
-    size_t hdr = (sizeof(uint8_t) * 2) + sizeof(int32_t);
-    size_t len;
-    int cpylen, left;
-
-    server->localClient->event = NULL;
-
-    recvqlen = rb_linebuf_len(&server->localClient->buf_recvq);
-
-    len = recvqlen + hdr;
-
-    if(len > READBUF_SIZE) {
-        sendto_realops_snomask(SNO_GENERAL, L_ALL,
-                               "ssld - attempted to pass message of %d len, max len %d, giving up",
-                               (int)len, READBUF_SIZE);
-        ilog(L_MAIN, "ssld - attempted to pass message of %d len, max len %d, giving up", (int)len, READBUF_SIZE);
-        exit_client(server, server, server, "ssld readbuf exceeded");
-        return;
-    }
-
-    buf = rb_malloc(len);
-    level = ConfigFileEntry.compression_level;
-
-    int32_to_buf(&buf[1], rb_get_fd(server->localClient->F));
-    buf[5] = (char) level;
-
-    recvq_start = &buf[6];
-    server->localClient->zipstats = rb_malloc(sizeof(struct ZipStats));
-
-    xbuf = recvq_start;
-    left = recvqlen;
-
-    do {
-        cpylen = rb_linebuf_get(&server->localClient->buf_recvq, xbuf, left, LINEBUF_PARTIAL, LINEBUF_RAW);
-        left -= cpylen;
-        xbuf = (void *) (((uintptr_t) xbuf) + cpylen);
-    } while(cpylen > 0);
-
-    /* Pass the socket to ssld. */
-    *buf = 'Z';
-    if(rb_socketpair(AF_UNIX, SOCK_STREAM, 0, &xF1, &xF2, "Initial zlib socketpairs") == -1) {
-        sendto_realops_snomask(SNO_GENERAL, L_ALL, "Error creating zlib socketpair - %s", strerror(errno));
-        ilog(L_MAIN, "Error creating zlib socketpairs - %s", strerror(errno));
-        exit_client(server, server, server, "Error creating zlib socketpair");
-        return;
-    }
-
-    if(IsSSL(server)) {
-        /* tell ssld the new connid for the ssl part*/
-        buf2[0] = 'Y';
-        int32_to_buf(&buf2[1], rb_get_fd(server->localClient->F));
-        int32_to_buf(&buf2[5], rb_get_fd(xF2));
-        ssl_cmd_write_queue(server->localClient->ssl_ctl, NULL, 0, buf2, sizeof(buf2));
-    }
-
-
-    F[0] = server->localClient->F;
-    F[1] = xF1;
-    del_from_cli_fd_hash(server);
-    server->localClient->F = xF2;
-    /* need to redo as what we did before isn't valid now */
-    int32_to_buf(&buf[1], rb_get_fd(server->localClient->F));
-    add_to_cli_fd_hash(server);
-
-    server->localClient->z_ctl = which_ssld();
-    server->localClient->z_ctl->cli_count++;
-    ssl_cmd_write_queue(server->localClient->z_ctl, F, 2, buf, len);
-    rb_free(buf);
-}
-
-static void
-collect_zipstats(void *unused)
-{
-    rb_dlink_node *ptr;
-    struct Client *target_p;
-    char buf[sizeof(uint8_t) + sizeof(int32_t) + HOSTLEN];
-    void *odata;
-    size_t len;
-
-    buf[0] = 'S';
-    odata = buf + sizeof(uint8_t) + sizeof(int32_t);
-
-    RB_DLINK_FOREACH(ptr, serv_list.head) {
-        target_p = ptr->data;
-        if(IsCapable(target_p, CAP_ZIP)) {
-            len = sizeof(uint8_t) + sizeof(uint32_t);
-
-            int32_to_buf(&buf[1], rb_get_fd(target_p->localClient->F));
-            rb_strlcpy(odata, target_p->name, (sizeof(buf) - len));
-            len += strlen(odata) + 1;	/* Get the \0 as well */
-            ssl_cmd_write_queue(target_p->localClient->z_ctl, NULL, 0, buf, len);
-        }
-    }
-}
-
 static void
 cleanup_dead_ssl(void *unused)
 {
@@ -803,6 +645,5 @@ get_ssld_count(void)
 void
 init_ssld(void)
 {
-    rb_event_addish("collect_zipstats", collect_zipstats, NULL, ZIPSTATS_TIME);
     rb_event_addish("cleanup_dead_ssld", cleanup_dead_ssl, NULL, 1200);
 }

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -365,6 +365,10 @@ ssl_process_certfp(ssl_ctl_t * ctl, ssl_ctl_buf_t * ctl_buf)
     client_p->certfp = certfp_string;
 }
 
+/**
+ * See ssld.c for documentation on the ipc used here
+ **/
+
 static void
 ssl_process_cmd_recv(ssl_ctl_t * ctl)
 {

--- a/src/sslproc.c
+++ b/src/sslproc.c
@@ -442,6 +442,7 @@ ssl_read_ctl(rb_fde_t * F, void *data)
     rb_setselect(ctl->F, RB_SELECT_READ, ssl_read_ctl, ctl);
 }
 
+/* Return the ssld with the fewest clients */
 static ssl_ctl_t *
 which_ssld(void)
 {

--- a/ssld/Makefile.am
+++ b/ssld/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/libratbox/include
 AM_LDFLAGS = -L$(top_srcdir)/libratbox/src
-LDADD = -lratbox -lz
+LDADD = -lratbox
 
 bin_PROGRAMS = ssld
 ssld_SOURCES = ssld.c

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -424,14 +424,10 @@ conn_plain_read_cb(rb_fde_t *fd, void *data)
     if(conn == NULL)
         return;
 
-    if(IsDead(conn))
-        return;
-
-    if(plain_check_cork(conn))
-        return;
-
     while(1) {
         if(IsDead(conn))
+            return;
+        if(plain_check_cork(conn))
             return;
 
         length = rb_read(conn->plain_fd, inbuf, sizeof(inbuf));
@@ -448,11 +444,6 @@ conn_plain_read_cb(rb_fde_t *fd, void *data)
         }
         conn->plain_in += length;
         conn_mod_write(conn, inbuf, length);
-
-        if(IsDead(conn))
-            return;
-        if(plain_check_cork(conn))
-            return;
     }
 }
 
@@ -495,8 +486,6 @@ conn_mod_read_cb(rb_fde_t *fd, void *data)
     if(IsSSLRWantsW(conn)) {
         ClearSSLRWantsW(conn);
         conn_mod_write_sendq(conn->mod_fd, conn);
-        if(IsDead(conn))
-            return;
     }
 
     while(1) {

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -161,30 +161,34 @@ typedef struct _conn {
     uint8_t flags;
 } conn_t;
 
-#define FLAG_SSL	0x01
-//define FLAG_ZIP	0x02 /* Removed */
-#define FLAG_CORK	0x04
-#define FLAG_DEAD	0x08
-#define FLAG_SSL_W_WANTS_R 0x10	/* output needs to wait until input possible */
-#define FLAG_SSL_R_WANTS_W 0x20	/* input needs to wait until output possible */
+#define FLAG_SSL           0x01
+//define FLAG_ZIP          0x02 /* Removed */
+#define FLAG_CORK          0x04
+#define FLAG_DEAD          0x08
+#define FLAG_SSL_W_WANTS_R 0x10 /* output needs to wait until input possible */
+#define FLAG_SSL_R_WANTS_W 0x20 /* input needs to wait until output possible */
+#define FLAG_SSL_HANDSHAKE 0x40
 
 #define IsSSL(x) ((x)->flags & FLAG_SSL)
 #define IsCork(x) ((x)->flags & FLAG_CORK)
 #define IsDead(x) ((x)->flags & FLAG_DEAD)
 #define IsSSLWWantsR(x) ((x)->flags & FLAG_SSL_W_WANTS_R)
 #define IsSSLRWantsW(x) ((x)->flags & FLAG_SSL_R_WANTS_W)
+#define IsSSLHandshakeDone(x) ((x)->flags & FLAG_SSL_HANDSHAKE)
 
 #define SetSSL(x) ((x)->flags |= FLAG_SSL)
 #define SetCork(x) ((x)->flags |= FLAG_CORK)
 #define SetDead(x) ((x)->flags |= FLAG_DEAD)
 #define SetSSLWWantsR(x) ((x)->flags |= FLAG_SSL_W_WANTS_R)
 #define SetSSLRWantsW(x) ((x)->flags |= FLAG_SSL_R_WANTS_W)
+#define SetSSLHandshakeDone(x) ((x)->flags |= FLAG_SSL_HANDSHAKE)
 
 #define ClearSSL(x) ((x)->flags &= ~FLAG_SSL)
 #define ClearCork(x) ((x)->flags &= ~FLAG_CORK)
 #define ClearDead(x) ((x)->flags &= ~FLAG_DEAD)
 #define ClearSSLWWantsR(x) ((x)->flags &= ~FLAG_SSL_W_WANTS_R)
 #define ClearSSLRWantsW(x) ((x)->flags &= ~FLAG_SSL_R_WANTS_W)
+#define ClearSSLHandshakeDone(x) ((x)->flags &= ~FLAG_SSL_HANDSHAKE)
 
 #define NO_WAIT 0x0
 #define WAIT_PLAIN 0x1
@@ -208,6 +212,13 @@ static void conn_plain_read_shutdown_cb(rb_fde_t *fd, void *data);
 static void mod_cmd_write_queue(mod_ctl_t * ctl, const void *data, size_t len);
 static const char *remote_closed = "Remote host closed the connection";
 static int ssl_ok;
+
+static void conn_handshake_accept(conn_t *);
+static void conn_handshake_connect(conn_t *);
+static void conn_ready(conn_t *);
+
+static void send_i_am_useless(mod_ctl_t * ctl);
+static void send_config_error(mod_ctl_t * ctl);
 
 static conn_t *
 conn_find_by_id(int32_t id)
@@ -572,8 +583,8 @@ ssl_process_accept_cb(rb_fde_t *F, int status, struct sockaddr *addr, rb_socklen
             int32_to_buf(&buf[1], conn->id);
             mod_cmd_write_queue(conn->ctl, buf, sizeof buf);
         }
-        conn_mod_read_cb(conn->mod_fd, conn);
-        conn_plain_read_cb(conn->plain_fd, conn);
+        SetSSLHandshakeDone(conn);
+        conn_handshake_accept(conn);
         return;
     }
     /* ircd doesn't care about the reason for this */
@@ -593,8 +604,8 @@ ssl_process_connect_cb(rb_fde_t *F, int status, void *data)
             int32_to_buf(&buf[1], conn->id);
             mod_cmd_write_queue(conn->ctl, buf, sizeof buf);
         }
-        conn_mod_read_cb(conn->mod_fd, conn);
-        conn_plain_read_cb(conn->plain_fd, conn);
+        SetSSLHandshakeDone(conn);
+        conn_handshake_connect(conn);
     } else if(status == RB_ERR_TIMEOUT)
         close_conn(conn, WAIT_PLAIN, "SSL handshake timed out");
     else if(status == RB_ERROR_SSL)
@@ -635,7 +646,7 @@ ssl_process_accept(mod_ctl_t * ctl, mod_ctl_buf_t * ctlb)
     if(rb_get_type(conn->mod_fd) == RB_FD_UNKNOWN)
         rb_set_type(conn->plain_fd, RB_FD_SOCKET);
 
-    rb_ssl_start_accepted(ctlb->F[0], ssl_process_accept_cb, conn, 10);
+    conn_handshake_accept(conn);
 }
 
 static void
@@ -657,8 +668,37 @@ ssl_process_connect(mod_ctl_t * ctl, mod_ctl_buf_t * ctlb)
     if(rb_get_type(conn->mod_fd) == RB_FD_UNKNOWN)
         rb_set_type(conn->plain_fd, RB_FD_SOCKET);
 
+    conn_handshake_connect(conn);
+}
 
-    rb_ssl_start_connected(ctlb->F[0], ssl_process_connect_cb, conn, 10);
+static void
+conn_handshake_accept(conn_t * conn)
+{
+    if(IsSSL(conn) && !IsSSLHandshakeDone(conn)) {
+        rb_ssl_start_accepted(conn->mod_fd, ssl_process_accept_cb, conn, 10);
+        return;
+    }
+
+    conn_ready(conn);
+}
+
+static void
+conn_handshake_connect(conn_t * conn)
+{
+    if(IsSSL(conn) && !IsSSLHandshakeDone(conn)) {
+        rb_ssl_start_connected(conn->mod_fd, ssl_process_connect_cb, conn, 10);
+        return;
+    }
+
+    conn_ready(conn);
+}
+
+/* Called when handshaking is done */
+static void
+conn_ready(conn_t *conn)
+{
+    rb_setselect(conn->mod_fd,   RB_SELECT_READ, conn_mod_read_cb,   conn);
+    rb_setselect(conn->plain_fd, RB_SELECT_READ, conn_plain_read_cb, conn);
 }
 
 static void

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -159,7 +159,6 @@ typedef struct _conn {
     unsigned long long plain_in;
     unsigned long long plain_out;
     uint8_t flags;
-    void *stream;
 } conn_t;
 
 #define FLAG_SSL	0x01
@@ -298,7 +297,6 @@ make_conn(mod_ctl_t * ctl, rb_fde_t *mod_fd, rb_fde_t *plain_fd)
     conn->mod_fd = mod_fd;
     conn->plain_fd = plain_fd;
     conn->id = -1;
-    conn->stream = NULL;
     rb_set_nb(mod_fd);
     rb_set_nb(plain_fd);
     return conn;

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -19,6 +19,67 @@
  *  USA
  */
 
+/**
+ * IPC format
+ *
+ * a dgram socket is created and inherited by to ssld.
+ *
+ * s_ctlfd = getenv("CTL_FD");
+ *
+ *----------------------------------------------------------------------
+ * Commands passed via ctl fd to ssld:
+ *
+ * Accept and Connect:
+ *  u8   u32
+ * ['A'|connection id]
+ * ['C'|connection id]
+ *
+ * Descriptors:
+ * [0]: mod_fd, ssl socket
+ * [1]: plain_fd, socket to the ircd for plaintext
+ *
+ *
+ * New keys:
+ *  u8  char[]
+ * ['K'|cert\0priv key\0(opt)dh params\0]
+ *
+ * Certificates and keys are passed as concantenated null terminated
+ * ascii (probably openssl format).
+ * dh params are optional
+ *
+ * Init PRNG:
+ *  u8  u8        char[]
+ * ['I'|seed_type|path'\0']
+ *
+ * This is intended to be passed to rb_init_prng pretty much unmodified
+ * seed_type is of type prng_seed_t, defined in rb_commio.h
+ *
+ *----------------------------------------------------------------------
+ * Commands passed via ctl fd from the ssld:
+ *
+ * Dead fd:
+ *  u8  u32           char[]
+ * ['D'|connection id|reason\0]
+ *
+ * Indicates a session has disconnected
+ *
+ * Cert fp:
+ *  u8  u32           u8[RB_SSL_CERTFP_LEN]
+ * ['F'|connection id|fingerprint]
+ *
+ * Certificate fingerprint for sasl authentication
+ *
+ * Nossl/I am useless/cannot initialize:
+ *  u8
+ * ['N']
+ * ['U']
+ * ['I']
+ *
+ * indicates that ssld can't do ssl (?)
+ * 'N' unknown
+ * 'U' ssld compiled without ssl support
+ * 'I' configuration error
+ **/
 
 #include "stdinc.h"
 


### PR DESCRIPTION
adds complexity and latency for a 50% bandwidth saving
given irc is not a bandwidth hog this doesn't seem to be a useful feature

add documentation for ssld's ipc